### PR TITLE
Support Python 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.6"
 keywords = ["human phenotype ontology", "HPO", "library"]
 license = { file = "LICENSE" }
 classifiers = [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python >=3.8
     - pip
   run:
-    - python >=3.8
+    - python >=3.6
     - numpy >= 1.10
 
 test:


### PR DESCRIPTION
We can support Python 3.6 and better as there is currently no functionality that would prevent us doing so.