### PR TITLE
Implement observation status for annotations

### DIFF
--- a/notebooks/Tutorial.ipynb
+++ b/notebooks/Tutorial.ipynb
@@ -540,8 +540,8 @@
     "\n",
     "# Long fingers is a parent of Arachnodactyly\n",
     "inputs = [\n",
-    "    MinimalTerm.create_minimal_term(TermId.from_curie('HP:0001166'), name='Arachnodactyly', alt_term_ids=[], is_obsolete=False),\n",
-    "    MinimalTerm.create_minimal_term(TermId.from_curie('HP:0100807'), name='Long fingers', alt_term_ids=[], is_obsolete=False)\n",
+    "    TermId.from_curie('HP:0001166'),  # Arachnodactyly\n",
+    "    TermId.from_curie('HP:0100807'),  # Long fingers\n",
     "]\n",
     "\n",
     "ap_validator = AnnotationPropagationValidator(o)\n",
@@ -557,7 +557,7 @@
     "assert val_result.category == 'annotation_propagation'\n",
     "\n",
     "# A message for human consumption\n",
-    "assert val_result.message == 'Terms should not contain both Arachnodactyly [HP:0001166] and its ancestor Long fingers [HP:0100807]'"
+    "assert val_result.message == 'Terms should not contain both present Arachnodactyly [HP:0001166] and its present or excluded ancestor Long fingers [HP:0100807]'"
    ]
   },
   {
@@ -584,8 +584,8 @@
     "\n",
     "# Long fingers is a parent of Arachnodactyly\n",
     "inputs = [\n",
-    "    MinimalTerm.create_minimal_term(TermId.from_curie('HP:0000007'), name='Autosomal recessive inheritance', alt_term_ids=[], is_obsolete=False),\n",
-    "    MinimalTerm.create_minimal_term(TermId.from_curie('HP:0100807'), name='Long fingers', alt_term_ids=[], is_obsolete=False)\n",
+    "    TermId.from_curie('HP:0000007'),  # Autosomal recessive inheritance\n",
+    "    TermId.from_curie('HP:0100807'),  # Long fingers\n",
     "]\n",
     "\n",
     "pa_validator = PhenotypicAbnormalityValidator(o)\n",
@@ -624,7 +624,7 @@
      "output_type": "stream",
      "text": [
       "Using the obsolete HP:0006010 instead of HP:0100807 for Long fingers\n",
-      "Terms should not contain both Arachnodactyly [HP:0001166] and its ancestor Long fingers [HP:0100807]\n",
+      "Terms should not contain both present Arachnodactyly [HP:0001166] and its present or excluded ancestor Long fingers [HP:0100807]\n",
       "Autosomal recessive inheritance [HP:0000007] is not a descendant of Phenotypic abnormality [HP:0000118]\n"
      ]
     }
@@ -633,9 +633,9 @@
     "from hpotk.validate import ValidationRunner\n",
     "\n",
     "inputs = [\n",
-    "    MinimalTerm.create_minimal_term(TermId.from_curie('HP:0000007'), name='Autosomal recessive inheritance', alt_term_ids=[], is_obsolete=False),\n",
-    "    MinimalTerm.create_minimal_term(TermId.from_curie('HP:0006010'), name='Long fingers', alt_term_ids=[], is_obsolete=False),\n",
-    "    MinimalTerm.create_minimal_term(TermId.from_curie('HP:0001166'), name='Arachnodactyly', alt_term_ids=[], is_obsolete=False),\n",
+    "    TermId.from_curie('HP:0000007'), # Autosomal recessive inheritance\n",
+    "    TermId.from_curie('HP:0006010'), # Long fingers\n",
+    "    TermId.from_curie('HP:0001166')  # Arachnodactyly\n",
     "]\n",
     "\n",
     "runner = ValidationRunner(validators=[obso_validator, ap_validator, pa_validator])\n",

--- a/src/hpotk/annotations/__init__.py
+++ b/src/hpotk/annotations/__init__.py
@@ -1,7 +1,6 @@
 from ._api import AnnotatedItem, AnnotatedItemContainer, ANNOTATED_ITEM, ANNOTATION
-from ._base import Ratio, EvidenceCode, Sex, AnnotationReference
+from ._base import EvidenceCode, Sex, AnnotationReference
 from ._base import HpoDiseaseAnnotation, HpoDisease, HpoDiseases
-from ._base import SimpleRatio
 
 from ._simple import SimpleHpoDiseaseAnnotation, SimpleHpoDisease, SimpleHpoDiseases
 

--- a/src/hpotk/annotations/_api.py
+++ b/src/hpotk/annotations/_api.py
@@ -2,7 +2,8 @@ import abc
 import typing
 import warnings
 
-from hpotk.model import TermId, Identified, Versioned
+from hpotk.model import Identified, ObservableFeature, Versioned
+from hpotk.model import TermId
 
 
 # #####################################################################################################################
@@ -12,30 +13,82 @@ from hpotk.model import TermId, Identified, Versioned
 # #####################################################################################################################
 
 
-class ObservableAnnotation(Identified, metaclass=abc.ABCMeta):
+class FrequencyAwareFeature(ObservableFeature, metaclass=abc.ABCMeta):
     """
-    An identified item with present or absent state.
+    `FrequencyAwareFeature` entities describe the frequency of a feature in one or more annotated items.
+
+    The simplest case is presence or absence of the feature in a single item, for instance the presence or absence
+    of a phenotypic feature, such as hypertension, in a study subject. Another use case is representation
+    of the feature frequency in a collection of items, such as presence of a phenotypic feature in a cohort.
+
+    The absolute counts are stored in the `numerator` and `denominator` attributes.
+
+    **IMPORTANT**: the implementor must check the following:
+     - the `numerator` must be a non-negative `int`
+     - the `denominator` must be a positive `int`
+
+    Use the convenience static method `FrequencyAwareFeature.check_numerator_and_denominator` to check the properties.
     """
 
     @property
     @abc.abstractmethod
-    def is_present(self) -> bool:
+    def numerator(self) -> int:
         """
-        :return: `True` if the annotation has been *observed* in the annotated object.
+        :return: a non-negative `int` representing the count of annotated items where the annotation was present.
         """
         pass
 
     @property
-    def is_absent(self) -> bool:
+    @abc.abstractmethod
+    def denominator(self) -> int:
         """
-        :return: `True` if the annotation has been *excluded* in the annotated object.
+        :return: a positive `int` representing the total count of annotated items investigated
+        for presence/absence of an annotation.
         """
-        return not self.is_present
+        pass
+
+    def frequency(self) -> float:
+        """
+
+        :return: a `float` in range :math:`[0, 1]` representing the ratio of the annotation in the annotated item(s).
+        """
+        return self.numerator / self.denominator
+
+    @property
+    def is_present(self) -> bool:
+        """
+        :return: `True` if the annotation was observed in one or more items.
+        """
+        return self.numerator != 0
+
+    @property
+    def is_excluded(self) -> bool:
+        """
+        :return: `True` if the annotation was observed in none of the annotated item(s), and therefore, excluded.
+        """
+        return self.numerator == 0
+
+    @staticmethod
+    def check_numerator_and_denominator(numerator: int, denominator: int) -> None:
+        """
+        Check if the `numerator` and `denominator` satisfy the requirements described in :class:`FrequencyAwareFeature`.
+
+        :return: `None` if the check passes or raises a `ValueError` if the `numerator` or `denominator` contain
+          invalid values.
+        """
+        if not isinstance(numerator, int) or numerator < 0:
+            raise ValueError(f'Numerator {numerator} must be a non-negative `int`')
+        if not isinstance(denominator, int) or denominator <= 0:
+            raise ValueError(f'Denominator {denominator} must be a positive `int`')
 
 
-ANNOTATION = typing.TypeVar('ANNOTATION', bound=ObservableAnnotation)
+class AnnotationBase(Identified, FrequencyAwareFeature, metaclass=abc.ABCMeta):
+    pass
+
+
+ANNOTATION = typing.TypeVar('ANNOTATION', bound=AnnotationBase)
 """
-A world item annotation with present or absent state.
+A world item annotation with an identifier and present or excluded state.
 """
 
 

--- a/src/hpotk/annotations/_api.py
+++ b/src/hpotk/annotations/_api.py
@@ -2,7 +2,7 @@ import abc
 import typing
 import warnings
 
-from hpotk.model import Identified, ObservableFeature, Versioned
+from hpotk.model import Identified, FrequencyAwareFeature, Versioned
 from hpotk.model import TermId
 
 
@@ -11,75 +11,6 @@ from hpotk.model import TermId
 # An example application includes phenotypic features (annotations), diseases or samples (annotated items),
 # and OMIM corpus (annotated item containers).
 # #####################################################################################################################
-
-
-class FrequencyAwareFeature(ObservableFeature, metaclass=abc.ABCMeta):
-    """
-    `FrequencyAwareFeature` entities describe the frequency of a feature in one or more annotated items.
-
-    The simplest case is presence or absence of the feature in a single item, for instance the presence or absence
-    of a phenotypic feature, such as hypertension, in a study subject. Another use case is representation
-    of the feature frequency in a collection of items, such as presence of a phenotypic feature in a cohort.
-
-    The absolute counts are stored in the `numerator` and `denominator` attributes.
-
-    **IMPORTANT**: the implementor must check the following:
-     - the `numerator` must be a non-negative `int`
-     - the `denominator` must be a positive `int`
-
-    Use the convenience static method `FrequencyAwareFeature.check_numerator_and_denominator` to check the properties.
-    """
-
-    @property
-    @abc.abstractmethod
-    def numerator(self) -> int:
-        """
-        :return: a non-negative `int` representing the count of annotated items where the annotation was present.
-        """
-        pass
-
-    @property
-    @abc.abstractmethod
-    def denominator(self) -> int:
-        """
-        :return: a positive `int` representing the total count of annotated items investigated
-        for presence/absence of an annotation.
-        """
-        pass
-
-    def frequency(self) -> float:
-        """
-
-        :return: a `float` in range :math:`[0, 1]` representing the ratio of the annotation in the annotated item(s).
-        """
-        return self.numerator / self.denominator
-
-    @property
-    def is_present(self) -> bool:
-        """
-        :return: `True` if the annotation was observed in one or more items.
-        """
-        return self.numerator != 0
-
-    @property
-    def is_excluded(self) -> bool:
-        """
-        :return: `True` if the annotation was observed in none of the annotated item(s), and therefore, excluded.
-        """
-        return self.numerator == 0
-
-    @staticmethod
-    def check_numerator_and_denominator(numerator: int, denominator: int) -> None:
-        """
-        Check if the `numerator` and `denominator` satisfy the requirements described in :class:`FrequencyAwareFeature`.
-
-        :return: `None` if the check passes or raises a `ValueError` if the `numerator` or `denominator` contain
-          invalid values.
-        """
-        if not isinstance(numerator, int) or numerator < 0:
-            raise ValueError(f'Numerator {numerator} must be a non-negative `int`')
-        if not isinstance(denominator, int) or denominator <= 0:
-            raise ValueError(f'Denominator {denominator} must be a positive `int`')
 
 
 class AnnotationBase(Identified, FrequencyAwareFeature, metaclass=abc.ABCMeta):

--- a/src/hpotk/annotations/_simple.py
+++ b/src/hpotk/annotations/_simple.py
@@ -3,18 +3,21 @@ import warnings
 
 from hpotk.model import TermId, CURIE_OR_TERM_ID
 from ._api import ANNOTATED_ITEM
-from ._base import AnnotationReference, Ratio
+from ._base import AnnotationReference
 from ._base import HpoDisease, HpoDiseaseAnnotation, HpoDiseases
 
 
 class SimpleHpoDiseaseAnnotation(HpoDiseaseAnnotation):
 
     def __init__(self, identifier: TermId,
-                 ratio: Ratio,
-                 references: typing.List[AnnotationReference],
-                 modifiers: typing.List[TermId]):
+                 numerator: int,
+                 denominator: int,
+                 references: typing.Sequence[AnnotationReference],
+                 modifiers: typing.Sequence[TermId]):
         self._id = identifier
-        self._ratio = ratio
+        self.check_numerator_and_denominator(numerator, denominator)
+        self._numerator = numerator
+        self._denominator = denominator
         self._refs = references
         self._modifiers = modifiers
 
@@ -23,16 +26,28 @@ class SimpleHpoDiseaseAnnotation(HpoDiseaseAnnotation):
         return self._id
 
     @property
-    def ratio(self) -> Ratio:
-        return self._ratio
+    def numerator(self) -> int:
+        return self._numerator
 
     @property
-    def references(self) -> typing.List[AnnotationReference]:
+    def denominator(self) -> int:
+        return self._denominator
+
+    @property
+    def references(self) -> typing.Sequence[AnnotationReference]:
         return self._refs
 
     @property
-    def modifiers(self) -> typing.List[TermId]:
+    def modifiers(self) -> typing.Sequence[TermId]:
         return self._modifiers
+
+    def __repr__(self):
+        return f"SimpleHpoDiseaseAnnotation(" \
+               f"identifier={self.identifier}, " \
+               f"numerator={self.numerator}, " \
+               f"denominator={self.denominator}, " \
+               f"references={self.references}, " \
+               f"modifiers={self.modifiers})"
 
 
 class SimpleHpoDisease(HpoDisease):

--- a/src/hpotk/annotations/load/hpoa/test__impl.py
+++ b/src/hpotk/annotations/load/hpoa/test__impl.py
@@ -1,15 +1,15 @@
-import unittest
 
+import unittest
 import ddt
 
-from hpotk.annotations import Ratio, EvidenceCode
+from ._impl import Ratio
 
 
 @ddt.ddt
 class TestRatio(unittest.TestCase):
 
     def test_positive(self):
-        ratio = Ratio.create(1, 4)
+        ratio = Ratio(1, 4)
         self.assertEqual(ratio.numerator, 1)
         self.assertEqual(ratio.denominator, 4)
         self.assertAlmostEqual(ratio.frequency, 1/4)
@@ -17,24 +17,12 @@ class TestRatio(unittest.TestCase):
         self.assertFalse(ratio.is_zero())
 
     def test_zero(self):
-        ratio = Ratio.create(0, 1)
+        ratio = Ratio(0, 1)
         self.assertEqual(ratio.numerator, 0)
         self.assertEqual(ratio.denominator, 1)
         self.assertAlmostEqual(ratio.frequency, 0.)
         self.assertFalse(ratio.is_positive())
         self.assertTrue(ratio.is_zero())
-
-    @ddt.unpack
-    @ddt.data(
-        [-1,  1, "Numerator -1 must be a non-negative `int`"],
-        [1,  0, "Denominator 0 must be a positive `int`"],
-        [1, -1, "Denominator -1 must be a positive `int`"],
-    )
-    def test_errors(self, numerator, denominator, msg):
-        with self.assertRaises(ValueError) as eh:
-            Ratio.create(numerator, denominator)
-
-        self.assertEqual(eh.exception.args[0], msg)
 
     @ddt.unpack
     @ddt.data(
@@ -46,8 +34,8 @@ class TestRatio(unittest.TestCase):
         [1, 8, 1, 4, False],
     )
     def test_equality(self, left_num, left_denom, right_num, right_denom, expected):
-        left = Ratio.create(left_num, left_denom)
-        right = Ratio.create(right_num, right_denom)
+        left = Ratio(left_num, left_denom)
+        right = Ratio(right_num, right_denom)
         self.assertEqual(left == right, expected)
 
     @ddt.unpack
@@ -56,28 +44,11 @@ class TestRatio(unittest.TestCase):
         [1, 2, 3, 4, 4, 6],
     )
     def test_fold(self, left_num, left_denom, right_num, right_denom, result_num, result_denom):
-        left = Ratio.create(left_num, left_denom)
-        right = Ratio.create(right_num, right_denom)
+        left = Ratio(left_num, left_denom)
+        right = Ratio(right_num, right_denom)
 
         result = Ratio.fold(left, right)
 
         self.assertEqual(result.numerator, result_num)
         self.assertEqual(result.denominator, result_denom)
 
-
-@ddt.ddt
-class TestEvidenceCode(unittest.TestCase):
-
-    @ddt.unpack
-    @ddt.data(
-        ['IEA'],
-        ['TAS'],
-        ['PCS'],
-    )
-    def test_parse_ok(self, code):
-        ec: EvidenceCode = EvidenceCode.parse(code)
-        self.assertEqual(ec, EvidenceCode[code])
-
-    def test_parse_error(self):
-        ec = EvidenceCode.parse('GIBBERISH')
-        self.assertIsNone(ec)

--- a/src/hpotk/annotations/test__base.py
+++ b/src/hpotk/annotations/test__base.py
@@ -1,0 +1,24 @@
+import unittest
+
+import ddt
+
+from ._base import EvidenceCode
+
+
+@ddt.ddt
+class TestEvidenceCode(unittest.TestCase):
+
+    @ddt.unpack
+    @ddt.data(
+        ['IEA'],
+        ['TAS'],
+        ['PCS'],
+    )
+    def test_parse_ok(self, code):
+        ec: EvidenceCode = EvidenceCode.parse(code)
+        self.assertEqual(ec, EvidenceCode[code])
+
+    def test_parse_error(self):
+        ec = EvidenceCode.parse('GIBBERISH')
+        self.assertIsNone(ec)
+

--- a/src/hpotk/annotations/test__simple.py
+++ b/src/hpotk/annotations/test__simple.py
@@ -1,0 +1,23 @@
+import unittest
+import ddt
+
+from hpotk.model import TermId
+
+from ._simple import SimpleHpoDiseaseAnnotation
+
+
+@ddt.ddt
+class TestSimpleHpoAnnotation(unittest.TestCase):
+
+    @ddt.unpack
+    @ddt.data(
+        [-1,  1, "Numerator -1 must be a non-negative `int`"],
+        [1,  0, "Denominator 0 must be a positive `int`"],
+        [1, -1, "Denominator -1 must be a positive `int`"],
+    )
+    def test_errors(self, numerator, denominator, msg):
+        tid = TermId.from_curie('HP:1234567')
+        with self.assertRaises(ValueError) as eh:
+            SimpleHpoDiseaseAnnotation(tid, numerator, denominator, (), ())
+
+        self.assertEqual(eh.exception.args[0], msg)

--- a/src/hpotk/graph/_csr_graph.py
+++ b/src/hpotk/graph/_csr_graph.py
@@ -27,7 +27,8 @@ class BaseCsrOntologyGraph(OntologyGraph, metaclass=abc.ABCMeta):
     def root(self) -> NODE:
         return self._root
 
-    def get_children(self, source: typing.Union[NODE, Identified], include_source: bool = False) -> typing.Iterable[NODE]:
+    def get_children(self, source: typing.Union[str, NODE, Identified],
+                     include_source: bool = False) -> typing.Iterable[NODE]:
         # In other words, find a row in the CSR corresponding to the `source`
         # and retrieve the columns to which the `source` is the PARENT.
         return map(self._get_node_for_idx,
@@ -35,14 +36,16 @@ class BaseCsrOntologyGraph(OntologyGraph, metaclass=abc.ABCMeta):
                                                             BaseCsrOntologyGraph.PARENT_RELATIONSHIP_CODE,
                                                             include_source))
 
-    def get_descendants(self, source: typing.Union[NODE, Identified], include_source: bool = False) -> typing.Iterable[NODE]:
+    def get_descendants(self, source: typing.Union[str, NODE, Identified],
+                        include_source: bool = False) -> typing.Iterable[NODE]:
         # See `self.get_children()` for explanation of `BaseCsrOntologyGraph.PARENT_RELATIONSHIP_CODE`.
         return map(self._get_node_for_idx,
                    self._traverse_graph(source,
                                         BaseCsrOntologyGraph.PARENT_RELATIONSHIP_CODE,
                                         include_source))
 
-    def get_parents(self, source: typing.Union[NODE, Identified], include_source: bool = False) -> typing.Iterable[NODE]:
+    def get_parents(self, source: typing.Union[str, NODE, Identified],
+                    include_source: bool = False) -> typing.Iterable[NODE]:
         # In other words, find a row in the CSR corresponding to the `source`
         # and retrieve the columns to which the `source` is the CHILD.
         return map(self._get_node_for_idx,
@@ -50,14 +53,15 @@ class BaseCsrOntologyGraph(OntologyGraph, metaclass=abc.ABCMeta):
                                                             BaseCsrOntologyGraph.CHILD_RELATIONSHIP_CODE,
                                                             include_source))
 
-    def get_ancestors(self, source: typing.Union[NODE, Identified], include_source: bool = False) -> typing.Iterable[NODE]:
+    def get_ancestors(self, source: typing.Union[str, NODE, Identified],
+                      include_source: bool = False) -> typing.Iterable[NODE]:
         # See `self.get_parents()` for explanation of `BaseCsrOntologyGraph.CHILD_RELATIONSHIP_CODE`.
         return map(self._get_node_for_idx,
                    self._traverse_graph(source,
                                         BaseCsrOntologyGraph.CHILD_RELATIONSHIP_CODE,
                                         include_source))
 
-    def is_leaf(self, node: typing.Union[NODE, Identified]) -> bool:
+    def is_leaf(self, node: typing.Union[str, NODE, Identified]) -> bool:
         for _ in self._get_node_indices_with_relationship(node, BaseCsrOntologyGraph.PARENT_RELATIONSHIP_CODE, False):
             return False
         return True
@@ -68,11 +72,10 @@ class BaseCsrOntologyGraph(OntologyGraph, metaclass=abc.ABCMeta):
     def __iter__(self) -> typing.Iterator[NODE]:
         return iter(self._nodes)
 
-    def _traverse_graph(self, source: typing.Union[NODE, Identified],
+    def _traverse_graph(self, source: typing.Union[str, NODE, Identified],
                         relationship,
                         include_source: bool) -> typing.Generator[int, None, None]:
-        if isinstance(source, Identified):
-            source = source.identifier
+        source: TermId = self._map_to_term_id(source)
         seen: set[int] = set()
         buffer: typing.Deque[int] = deque()
 
@@ -91,11 +94,10 @@ class BaseCsrOntologyGraph(OntologyGraph, metaclass=abc.ABCMeta):
 
             yield current
 
-    def _get_node_indices_with_relationship(self, source: typing.Union[NODE, Identified],
+    def _get_node_indices_with_relationship(self, source: typing.Union[str, NODE, Identified],
                                             relationship,
                                             include_source: bool) -> typing.Generator[int, None, None]:
-        if isinstance(source, Identified):
-            source = source.identifier
+        source: TermId = self._map_to_term_id(source)
         row_idx = self._get_idx_for_node(source)
         if include_source:
             yield row_idx

--- a/src/hpotk/graph/test__api.py
+++ b/src/hpotk/graph/test__api.py
@@ -156,6 +156,24 @@ class TestCsrOntologyGraph(unittest.TestCase):
         self.assertSetEqual(set(self.GRAPH.get_descendants(SimpleIdentified.from_curie('HP:01'))),
                             {TermId.from_curie('HP:010'), TermId.from_curie('HP:011'), TermId.from_curie('HP:0110')})
 
+    def test_graph_queries_work_with_str(self):
+        # tests
+        self.assertTrue(self.GRAPH.is_ancestor_of('HP:01', 'HP:0110'))
+        self.assertTrue(self.GRAPH.is_parent_of('HP:01', 'HP:010'))
+        self.assertTrue(self.GRAPH.is_child_of('HP:01', 'HP:1'))
+        self.assertTrue(self.GRAPH.is_descendant_of('HP:01', 'HP:1'))
+        self.assertTrue(self.GRAPH.is_leaf('HP:03'))
+
+        # traversal
+        self.assertSetEqual(set(self.GRAPH.get_ancestors('HP:010')),
+                            {TermId.from_curie('HP:01'), TermId.from_curie('HP:1')})
+        self.assertSetEqual(set(self.GRAPH.get_parents('HP:01')),
+                            {TermId.from_curie('HP:1')})
+        self.assertSetEqual(set(self.GRAPH.get_children('HP:01')),
+                            {TermId.from_curie('HP:010'), TermId.from_curie('HP:011')})
+        self.assertSetEqual(set(self.GRAPH.get_descendants('HP:01')),
+                            {TermId.from_curie('HP:010'), TermId.from_curie('HP:011'), TermId.from_curie('HP:0110')})
+
 
 class SimpleIdentified(Identified):
 

--- a/src/hpotk/model/__init__.py
+++ b/src/hpotk/model/__init__.py
@@ -1,7 +1,7 @@
 import typing
 
 from ._term_id import TermId
-from ._base import Identified, ObservableFeature, Named, Versioned, MetadataAware
+from ._base import Identified, ObservableFeature, FrequencyAwareFeature, Named, Versioned, MetadataAware
 from ._term import MinimalTerm, Term, Synonym, SynonymType, SynonymCategory
 
 # Types

--- a/src/hpotk/model/__init__.py
+++ b/src/hpotk/model/__init__.py
@@ -1,7 +1,7 @@
 import typing
 
 from ._term_id import TermId
-from ._base import Identified, Named, Versioned, MetadataAware
+from ._base import Identified, ObservableFeature, PhenotypeFeature, Named, Versioned, MetadataAware
 from ._term import MinimalTerm, Term, Synonym, SynonymType, SynonymCategory
 
 # Types

--- a/src/hpotk/model/__init__.py
+++ b/src/hpotk/model/__init__.py
@@ -1,7 +1,7 @@
 import typing
 
 from ._term_id import TermId
-from ._base import Identified, ObservableFeature, PhenotypeFeature, Named, Versioned, MetadataAware
+from ._base import Identified, ObservableFeature, Named, Versioned, MetadataAware
 from ._term import MinimalTerm, Term, Synonym, SynonymType, SynonymCategory
 
 # Types

--- a/src/hpotk/model/_base.py
+++ b/src/hpotk/model/_base.py
@@ -48,6 +48,75 @@ class ObservableFeature(metaclass=abc.ABCMeta):
         return not self.is_present
 
 
+class FrequencyAwareFeature(ObservableFeature, metaclass=abc.ABCMeta):
+    """
+    `FrequencyAwareFeature` entities describe the frequency of a feature in one or more annotated items.
+
+    The simplest case is presence or absence of the feature in a single item, for instance the presence or absence
+    of a phenotypic feature, such as hypertension, in a study subject. Another use case is representation
+    of the feature frequency in a collection of items, such as presence of a phenotypic feature in a cohort.
+
+    The absolute counts are stored in the `numerator` and `denominator` attributes.
+
+    **IMPORTANT**: the implementor must check the following:
+     - the `numerator` must be a non-negative `int`
+     - the `denominator` must be a positive `int`
+
+    Use the convenience static method `FrequencyAwareFeature.check_numerator_and_denominator` to check the properties.
+    """
+
+    @property
+    @abc.abstractmethod
+    def numerator(self) -> int:
+        """
+        :return: a non-negative `int` representing the count of annotated items where the annotation was present.
+        """
+        pass
+
+    @property
+    @abc.abstractmethod
+    def denominator(self) -> int:
+        """
+        :return: a positive `int` representing the total count of annotated items investigated
+        for presence/absence of an annotation.
+        """
+        pass
+
+    def frequency(self) -> float:
+        """
+
+        :return: a `float` in range :math:`[0, 1]` representing the ratio of the annotation in the annotated item(s).
+        """
+        return self.numerator / self.denominator
+
+    @property
+    def is_present(self) -> bool:
+        """
+        :return: `True` if the annotation was observed in one or more items.
+        """
+        return self.numerator != 0
+
+    @property
+    def is_excluded(self) -> bool:
+        """
+        :return: `True` if the annotation was observed in none of the annotated item(s), and therefore, excluded.
+        """
+        return self.numerator == 0
+
+    @staticmethod
+    def check_numerator_and_denominator(numerator: int, denominator: int) -> None:
+        """
+        Check if the `numerator` and `denominator` satisfy the requirements described in :class:`FrequencyAwareFeature`.
+
+        :return: `None` if the check passes or raises a `ValueError` if the `numerator` or `denominator` contain
+          invalid values.
+        """
+        if not isinstance(numerator, int) or numerator < 0:
+            raise ValueError(f'Numerator {numerator} must be a non-negative `int`')
+        if not isinstance(denominator, int) or denominator <= 0:
+            raise ValueError(f'Denominator {denominator} must be a positive `int`')
+
+
 class Named(metaclass=abc.ABCMeta):
     """
     An entity that has human-readable name or label.

--- a/src/hpotk/model/_base.py
+++ b/src/hpotk/model/_base.py
@@ -48,15 +48,6 @@ class ObservableFeature(metaclass=abc.ABCMeta):
         return not self.is_present
 
 
-class PhenotypeFeature(Identified, ObservableFeature, metaclass=abc.ABCMeta):
-    """
-    `PhenotypeFeature` is a feature that has an identifier, as described in :class:`Identified`,
-    and can be present or excluded, as in :class:`ObservableFeature`.
-
-    """
-    pass
-
-
 class Named(metaclass=abc.ABCMeta):
     """
     An entity that has human-readable name or label.

--- a/src/hpotk/model/_base.py
+++ b/src/hpotk/model/_base.py
@@ -1,5 +1,6 @@
 import abc
 import typing
+import warnings
 
 from ._term_id import TermId
 
@@ -16,6 +17,44 @@ class Identified(metaclass=abc.ABCMeta):
         :return: the identifier of the entity.
         """
         pass
+
+
+class ObservableFeature(metaclass=abc.ABCMeta):
+    """
+    `ObservableFeature` represents a feature that can be either in a present or excluded state
+    in the investigated item(s).
+    """
+
+    @property
+    @abc.abstractmethod
+    def is_present(self) -> bool:
+        """
+        :return: `True` if the feature was observed in one or more items.
+        """
+        pass
+
+    @property
+    def is_absent(self) -> bool:
+        # REMOVE[v1.0.0]
+        warnings.warn("`is_absent` was deprecated and will be removed in v1.0.0. Use `is_excluded` instead",
+                      DeprecationWarning, stacklevel=2)
+        return self.is_excluded
+
+    @property
+    def is_excluded(self) -> bool:
+        """
+        :return: `True` if the feature was observed in none of the annotated item(s), and therefore, excluded.
+        """
+        return not self.is_present
+
+
+class PhenotypeFeature(Identified, ObservableFeature, metaclass=abc.ABCMeta):
+    """
+    `PhenotypeFeature` is a feature that has an identifier, as described in :class:`Identified`,
+    and can be present or excluded, as in :class:`ObservableFeature`.
+
+    """
+    pass
 
 
 class Named(metaclass=abc.ABCMeta):

--- a/src/hpotk/ontology/_default.py
+++ b/src/hpotk/ontology/_default.py
@@ -138,4 +138,4 @@ def _validate_term_id(term_id: CURIE_OR_TERM_ID) -> ID:
     elif isinstance(term_id, str):
         return TermId.from_curie(term_id)
     else:
-        raise ValueError(f'Expected a `{type(TermId)}` or a `str` but got {type(term_id)}')
+        raise ValueError(f'Expected a `TermId` or a `str` but got {type(term_id)}')

--- a/src/hpotk/validate/_hpo.py
+++ b/src/hpotk/validate/_hpo.py
@@ -1,28 +1,39 @@
 import abc
 import typing
 
-from hpotk.algorithm import get_ancestors
 from hpotk.model import Identified, TermId
 from hpotk.ontology import MinimalOntology
 from hpotk.constants.hpo.base import PHENOTYPIC_ABNORMALITY
+from hpotk.util import validate_instance
 
 from ._model import ValidationResult, ValidationResults, ValidationLevel, RuleValidator
+from ._util import SimpleFeature
+
+T = typing.TypeVar('T', SimpleFeature, TermId)
 
 
 class BaseOntologyRuleValidator(RuleValidator, metaclass=abc.ABCMeta):
 
-    def __init__(self, ontology: MinimalOntology):
-        if not isinstance(ontology, MinimalOntology):
-            raise ValueError(f'ontology must be an instance of hpotk.ontology.MinimalOntology '
-                             f'but it was an instance of {type(ontology)}')
-        self._ontology = ontology
+    def __init__(self, hpo: MinimalOntology):
+        self._hpo = validate_instance(hpo, MinimalOntology, 'hpo')
 
-    def _primary_term_id(self, identifier: TermId) -> typing.Optional[TermId]:
+    def _primary_term_id(self, feature: T) -> typing.Optional[T]:
         """
-        Map the provided `identifier` into the primary term ID in case the `identifier` is obsolete.
+        Update the term ID of the `feature` to the primary term ID in case the current term ID is obsolete.
         """
-        current_term = self._ontology.get_term(identifier)
-        return current_term.identifier if current_term is not None else None
+        if isinstance(feature, SimpleFeature):
+            current_id = self._hpo.get_term(feature.identifier)
+            if current_id is None:
+                return None
+            if current_id.identifier != feature.identifier:
+                # Update to the primary term ID.
+                feature.identifier = current_id.identifier
+            return feature
+        elif isinstance(feature, TermId):
+            current = self._hpo.get_term(feature)
+            return None if current is None else current.identifier
+        else:
+            raise ValueError(f'feature must be either a `TermId` or `SimpleFeature` but was {type(feature)}')
 
 
 class AnnotationPropagationValidator(BaseOntologyRuleValidator):
@@ -36,20 +47,41 @@ class AnnotationPropagationValidator(BaseOntologyRuleValidator):
         super().__init__(ontology)
 
     def validate(self, items: typing.Sequence[typing.Union[Identified, TermId]]) -> ValidationResults:
-        term_ids = {self._primary_term_id(self.extract_term_id(item)) for item in items}
+        stateful_features: typing.Collection[SimpleFeature] = {
+            self._primary_term_id(self._extract_stateful_feature(item))
+            for item in items
+            if item is not None
+        }
         results = []
-        for term_id in term_ids:
-            for ancestor in get_ancestors(self._ontology, source=term_id, include_source=False):
-                if ancestor in term_ids:
-                    current_term = self._ontology.get_term(term_id)
-                    ancestor_term = self._ontology.get_term(ancestor)
-                    results.append(
-                        ValidationResult(level=ValidationLevel.ERROR,
-                                         category='annotation_propagation',
-                                         message=f'Terms should not contain both '
-                                                 f'{current_term.name} [{current_term.identifier.value}] '
-                                                 f'and its ancestor '
-                                                 f'{ancestor_term.name} [{ancestor_term.identifier.value}]'))
+        for feature in stateful_features:
+            if feature.is_present:
+                # A present feature cannot coexist with a present or excluded ancestor.
+                for anc in self._hpo.graph.get_ancestors(feature):
+                    if any(anc == sf.identifier for sf in stateful_features):
+                        current_term = self._hpo.get_term(feature.identifier)
+                        term = self._hpo.get_term(anc)
+                        results.append(
+                            ValidationResult(level=ValidationLevel.ERROR,
+                                             category='annotation_propagation',
+                                             message=f'Terms should not contain both present '
+                                                     f'{current_term.name} [{current_term.identifier.value}] '
+                                                     f'and its present or excluded ancestor '
+                                                     f'{term.name} [{term.identifier.value}]'))
+            else:
+                # An excluded feature cannot coexist with an excluded ancestor.
+                for anc in self._hpo.graph.get_ancestors(feature):
+                    # We only check excluded ancestors here since presence of an ancestor is allowed
+                    # for an excluded feature.
+                    if any(anc == sf.identifier for sf in stateful_features if sf.is_excluded):
+                        current_term = self._hpo.get_term(feature.identifier)
+                        term = self._hpo.get_term(anc)
+                        results.append(
+                            ValidationResult(level=ValidationLevel.ERROR,
+                                             category='annotation_propagation',
+                                             message=f'Terms should not contain both excluded '
+                                                     f'{current_term.name} [{current_term.identifier.value}] '
+                                                     f'and its present or excluded ancestor '
+                                                     f'{term.name} [{term.identifier.value}]'))
 
         return ValidationResults(results)
 
@@ -68,11 +100,13 @@ class PhenotypicAbnormalityValidator(BaseOntologyRuleValidator):
     def validate(self, items: typing.Sequence[typing.Union[Identified, TermId]]) -> ValidationResults:
         results = []
         for item in items:
-            term_id = self.extract_term_id(item)
-            term_id = self._primary_term_id(term_id)
-            ancestors = get_ancestors(self._ontology, source=term_id, include_source=False)
-            if PHENOTYPIC_ABNORMALITY not in ancestors:
-                item = self._ontology.get_term(term_id)
+            primary = self._primary_term_id(self._extract_stateful_feature(item))
+            if primary is None:
+                # Unable to get the primary term ID. Handling items with obsolete IDs is not the responsibility
+                # of this validator
+                continue
+            if not any(PHENOTYPIC_ABNORMALITY == anc for anc in self._hpo.graph.get_ancestors(primary)):
+                item = self._hpo.get_term(primary.identifier)
                 results.append(
                     ValidationResult(
                         level=ValidationLevel.ERROR,
@@ -93,15 +127,16 @@ class ObsoleteTermIdsValidator(BaseOntologyRuleValidator):
     def validate(self, items: typing.Sequence[typing.Union[Identified, TermId]]) -> ValidationResults:
         results = []
         for item in items:
-            term_id = self.extract_term_id(item)
-            current_id = self._primary_term_id(term_id)
-            if current_id != term_id:
-                current_term = self._ontology.get_term(current_id)
+            sf = self._extract_stateful_feature(item)
+            current = sf.identifier  # cache the ID since _primary_term_id can update in place.
+            primary = self._primary_term_id(sf)
+            if primary.identifier != current:
+                current_term = self._hpo.get_term(sf.identifier)
                 results.append(
                     ValidationResult(
                         level=ValidationLevel.WARNING,
                         category='obsolete_term_id_is_used',
-                        message=f'Using the obsolete {term_id} instead of {current_id.value} '
+                        message=f'Using the obsolete {current.value} instead of {primary.identifier.value} '
                                 f'for {current_term.name}'
                     )
                 )

--- a/src/hpotk/validate/_model.py
+++ b/src/hpotk/validate/_model.py
@@ -5,6 +5,7 @@ import enum
 from collections import namedtuple
 
 from hpotk.model import Identified, TermId
+from ._util import SimpleFeature, map_to_stateful_feature
 
 
 class ValidationLevel(enum.Enum):
@@ -39,8 +40,8 @@ class ValidationResults:
 
 class RuleValidator(metaclass=abc.ABCMeta):
     """
-    `RuleValidator` checks if a sequence of :class:`Identified` or :class:`TermId` instances meet
-    the validation requirements.
+    `RuleValidator` checks if a sequence of :class:`Identified` or :class:`TermId` items meet
+    the validation requirements. The observation status is included in case the items extend :class:`ObservableFeature`.
 
     The validators can check each item individually or as a collection, for instance,
     to discover violation of the annotation propagation rule, etc.
@@ -53,13 +54,8 @@ class RuleValidator(metaclass=abc.ABCMeta):
         pass
 
     @staticmethod
-    def extract_term_id(item: typing.Union[Identified, TermId]) -> TermId:
-        if isinstance(item, Identified):
-            return item.identifier
-        elif isinstance(item, TermId):
-            return item
-        else:
-            raise ValueError(f'Item {item} of type {type(item)} is not a TermId nor extends Identified')
+    def _extract_stateful_feature(item: typing.Union[Identified, TermId]) -> SimpleFeature:
+        return map_to_stateful_feature(item)
 
 
 class ValidationRunner:

--- a/src/hpotk/validate/_util.py
+++ b/src/hpotk/validate/_util.py
@@ -1,0 +1,53 @@
+import typing
+
+from hpotk.model import TermId, Identified, ObservableFeature
+
+
+# #################################################################################################################### #
+# Non-public utilities
+# #################################################################################################################### #
+
+
+class SimpleFeature(Identified, ObservableFeature):
+
+    def __init__(self, identifier: TermId, status: bool):
+        self._id = identifier
+        self._status = status
+
+    @property
+    def identifier(self) -> TermId:
+        return self._id
+
+    @identifier.setter
+    def identifier(self, value: TermId):
+        self._id = value
+
+    @property
+    def is_present(self) -> bool:
+        return self._status
+
+
+def map_to_stateful_feature(feature: typing.Union[Identified, TermId]) -> SimpleFeature:
+    if isinstance(feature, Identified):
+        term_id = feature.identifier
+        if hasattr(feature, 'is_present'):
+            attr = feature.is_present
+            if hasattr(attr, '__call__'):
+                status = attr()
+                if not isinstance(status, bool):
+                    raise ValueError(f'Feature {feature} has a callable `is_present` but it does not produce a `bool` '
+                                     f'but {type(status)}')
+            elif isinstance(attr, bool):
+                status = attr
+            else:
+                raise ValueError(f'Feature {feature} has `is_present` attribute but the attribute is not a callable '
+                                 f'or a `bool`')
+        else:
+            status = True  # we assume the feature was observed
+    elif isinstance(feature, TermId):
+        term_id = feature
+        status = True  # we assume the feature was observed
+    else:
+        raise ValueError(f'Feature {feature} must implement `TermId` or `Identified`')
+
+    return SimpleFeature(term_id, status)

--- a/tests/algorithm/test_traversal.py
+++ b/tests/algorithm/test_traversal.py
@@ -4,14 +4,11 @@ import unittest
 import ddt
 from pkg_resources import resource_filename
 
-import hpotk as hp
 from hpotk.model import TermId
 from hpotk.ontology import MinimalOntology
 from hpotk.ontology.load.obographs import load_minimal_ontology
 
 TOY_HPO = resource_filename(__name__, os.path.join('../data', 'hp.toy.json'))
-
-hp.util.setup_logging()
 
 
 @ddt.ddt
@@ -29,8 +26,7 @@ class TestTraversal(unittest.TestCase):
     )
     @ddt.unpack
     def test_get_parents(self, source: str, include_source, expected):
-        parents = hp.algorithm.get_parents(self.HPO, source, include_source)
-        self.assertIsInstance(parents, frozenset)
+        parents = set(self.HPO.graph.get_parents(source, include_source))
         self.assertSetEqual(parents, {TermId.from_curie(val) for val in expected})
 
     @ddt.data(
@@ -47,8 +43,7 @@ class TestTraversal(unittest.TestCase):
     )
     @ddt.unpack
     def test_get_ancestors(self, source: str, include_source, expected):
-        ancestors = hp.algorithm.get_ancestors(self.HPO, source, include_source)
-        self.assertIsInstance(ancestors, frozenset)
+        ancestors = set(self.HPO.graph.get_ancestors(source, include_source))
         self.assertSetEqual(ancestors, {TermId.from_curie(val) for val in expected})
 
     @ddt.data(
@@ -57,8 +52,7 @@ class TestTraversal(unittest.TestCase):
     )
     @ddt.unpack
     def test_get_children(self, source: str, include_source, expected):
-        children = hp.algorithm.get_children(self.HPO, source, include_source)
-        self.assertIsInstance(children, frozenset)
+        children = set(self.HPO.graph.get_children(source, include_source))
         self.assertSetEqual(children, {TermId.from_curie(val) for val in expected})
 
     @ddt.data(
@@ -67,11 +61,10 @@ class TestTraversal(unittest.TestCase):
     )
     @ddt.unpack
     def test_get_descendants(self, source: str, include_source, expected):
-        descendants = hp.algorithm.get_descendants(self.HPO, source, include_source)
-        self.assertIsInstance(descendants, frozenset)
+        descendants = set(self.HPO.graph.get_descendants(source, include_source))
         self.assertSetEqual(descendants, {TermId.from_curie(val) for val in expected})
 
     def test_we_get_correct_number_of_descendants(self):
         all_term_id = "HP:0000001"
-        self.assertEqual(len(self.HPO) - 1, len(hp.algorithm.get_descendants(self.HPO, all_term_id)))
-        self.assertEqual(len(self.HPO), len(hp.algorithm.get_descendants(self.HPO, all_term_id, include_source=True)))
+        self.assertEqual(len(self.HPO) - 1, len(list(self.HPO.graph.get_descendants(all_term_id))))
+        self.assertEqual(len(self.HPO), len(list(self.HPO.graph.get_descendants(all_term_id, include_source=True))))

--- a/tests/annotations/load/test_hpoa.py
+++ b/tests/annotations/load/test_hpoa.py
@@ -63,14 +63,14 @@ class TestHpoaDiseaseProperties(TestHpoaLoaderBase):
         first = omim_annotations[0]
         self.assertEqual(first.identifier.value, 'HP:0001167')
         self.assertEqual(first.is_present, True)
-        self.assertEqual(first.ratio.numerator, 5)
-        self.assertEqual(first.ratio.denominator, 13)
+        self.assertEqual(first.numerator, 5)
+        self.assertEqual(first.denominator, 13)
         self.assertEqual(len(first.references), 2)
         self.assertSetEqual({m.value for m in first.modifiers}, {'HP:0012832', 'HP:0012828'})
 
         second = omim_annotations[1]
         self.assertEqual(second.identifier.value, 'HP:0001238')
-        self.assertEqual(second.is_absent, True)
-        self.assertEqual(second.ratio.numerator, 0)
-        self.assertEqual(second.ratio.denominator, TestHpoaDiseaseProperties.LOADER.cohort_size)
+        self.assertEqual(second.is_excluded, True)
+        self.assertEqual(second.numerator, 0)
+        self.assertEqual(second.denominator, TestHpoaDiseaseProperties.LOADER.cohort_size)
         self.assertEqual(len(second.references), 1)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,13 +4,28 @@ import unittest
 import ddt
 from pkg_resources import resource_filename
 
-from hpotk.model import MinimalTerm, TermId
+from hpotk.model import Identified, ObservableFeature, TermId
 from hpotk.ontology.load.obographs import load_minimal_ontology
 from hpotk.validate import ValidationResult, ValidationLevel
 from hpotk.validate import AnnotationPropagationValidator, PhenotypicAbnormalityValidator, ObsoleteTermIdsValidator
 
 
 TOY_HPO = resource_filename(__name__, os.path.join('data', 'hp.toy.json'))
+
+
+class SimpleFeature(Identified, ObservableFeature):
+
+    def __init__(self, curie: str, status: bool):
+        self._id = TermId.from_curie(curie)
+        self._status = status
+
+    @property
+    def identifier(self) -> TermId:
+        return self._id
+
+    @property
+    def is_present(self) -> bool:
+        return self._status
 
 
 class TestBaseRuleValidator(unittest.TestCase):
@@ -22,15 +37,10 @@ class TestBaseRuleValidator(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.o = load_minimal_ontology(TOY_HPO)
         cls.example_terms = [
-            MinimalTerm.create_minimal_term(
-                TermId.from_curie('HP:0001166'),
-                name='Arachnodactyly', alt_term_ids=[], is_obsolete=False),
-            MinimalTerm.create_minimal_term(
-                TermId.from_curie('HP:0002266'),
-                name='Focal clonic seizure', alt_term_ids=[], is_obsolete=False),
-            MinimalTerm.create_minimal_term(
-                TermId.from_curie('HP:0032648'),
-                name='Tubularization of Bowman capsule', alt_term_ids=[], is_obsolete=False)
+            SimpleFeature('HP:0001166', True),  # Arachnodactyly
+            SimpleFeature('HP:0001250', True),  # Seizure
+            SimpleFeature('HP:0032648', True),  # Tubularization of Bowman capsule
+            SimpleFeature('HP:0000805', False)  # excluded Enuresis
         ]
 
 
@@ -48,23 +58,46 @@ class TestAnnotationPropagationValidator(TestBaseRuleValidator):
         results = self.validator.validate(self.example_terms)
         self.assertTrue(results.is_ok())
 
-    @ddt.data(
-        ("HP:0100807", "HP:0100807", "Long fingers"),
-        ("HP:0006010", 'HP:0100807', "Long fingers"),
-    )
-    @ddt.unpack
-    def test_ancestor_presence_produces_error(self, query_id, current_id, name):
+    def test_obsolete_ancestor_produces_error(self):
         example_terms = list(self.example_terms)
-        example_terms.append(
-            MinimalTerm.create_minimal_term(
-                TermId.from_curie(query_id), name=name, alt_term_ids=[], is_obsolete=False)
-        )
+        example_terms.append(TermId.from_curie('HP:0006010'))
+
         results = self.validator.validate(example_terms)
+
         self.assertFalse(results.is_ok())
         self.assertEqual(results.results[0],
                          ValidationResult(level=ValidationLevel.ERROR, category='annotation_propagation',
-                                          message='Terms should not contain both Arachnodactyly [HP:0001166] '
-                                                  f'and its ancestor {name} [{current_id}]'))
+                                          message='Terms should not contain both present Arachnodactyly [HP:0001166] '
+                                                  f'and its present or excluded ancestor Long fingers [HP:0100807]'))
+
+    @ddt.data(
+        ("HP:0100807", True, 'HP:0001166', True),   # present Long fingers vs. present Arachnodactyly
+        ("HP:0100807", False, 'HP:0001166', True),  # excluded Long fingers vs. present Arachnodactyly
+
+        # The case is commented out since it is possible to have some abnormality but excluded specific abnormality
+        # ("HP:0000014", True, 'HP:0000805', False),  # present Abnormality of the bladder vs. excluded Enuresis
+
+        ("HP:0000014", False, 'HP:0000805', False),  # excluded Abnormality of the bladder vs. excluded Enuresis
+    )
+    @ddt.unpack
+    def test_ancestor_presence_produces_error(self, ancestor_curie, ancestor_status, base_curie, base_status):
+        example_terms = list(self.example_terms)
+        example_terms.append(SimpleFeature(ancestor_curie, ancestor_status))
+
+        results = self.validator.validate(example_terms)
+
+        self.assertFalse(results.is_ok())
+        self.assertEqual(1, len(results.results))
+        first = results.results[0]
+        self.assertEqual(ValidationLevel.ERROR, first.level)
+        self.assertEqual('annotation_propagation', first.category)
+
+        state = 'present' if base_status else 'excluded'
+        self.assertEqual(f'Terms should not contain both {state} '
+                         f'{self.o.get_term(base_curie).name} [{self.o.get_term(base_curie).identifier.value}] '
+                         f'and its present or excluded ancestor '
+                         f'{self.o.get_term(ancestor_curie).name} [{ancestor_curie}]',
+                         first.message)
 
 
 @ddt.ddt
@@ -78,22 +111,19 @@ class TestPhenotypicAbnormalityValidator(TestBaseRuleValidator):
         self.assertTrue(results.is_ok())
 
     @ddt.data(
-        ("HP:0012823", "HP:0012823", "Clinical modifier"),
-        ("HP:0003825", 'HP:0003828', "Variable expressivity"),
-        ("HP:0003621", 'HP:0003621', "Juvenile onset"),
+        ("HP:0012823",),  # Clinical modifier
+        ("HP:0003825",),  # Variable expressivity
+        ("HP:0003621",),  # Juvenile onset
     )
     @ddt.unpack
-    def test_clinical_modifier_presence_produces_error(self, query_id, current_id, name):
+    def test_presence_of_clinical_modifier_produces_error(self, curie):
         example_terms = list(self.example_terms)
-        example_terms.append(
-            MinimalTerm.create_minimal_term(
-                TermId.from_curie(query_id), name=name, alt_term_ids=[], is_obsolete=False)
-        )
+        example_terms.append(SimpleFeature(curie, True))
         results = self.validator.validate(example_terms)
         self.assertFalse(results.is_ok())
         self.assertEqual(results.results[0],
                          ValidationResult(level=ValidationLevel.ERROR, category='phenotypic_abnormality_descendant',
-                                          message=f'{name} [{current_id}] is not a descendant of '
+                                          message=f'{self.o.get_term(curie).name} [{self.o.get_term(curie).identifier.value}] is not a descendant of '
                                                   'Phenotypic abnormality [HP:0000118]'))
 
 
@@ -107,18 +137,14 @@ class TestObsoleteTermIdsValidator(TestBaseRuleValidator):
         results = self.validator.validate(self.example_terms)
         self.assertTrue(results.is_ok())
 
-    @ddt.data(
-        ("HP:0006010", 'HP:0100807', "Long fingers"),
-    )
-    @ddt.unpack
-    def test_clinical_modifier_presence_produces_error(self, query_id, current_id, name):
+    def test_presence_of_an_obsolete_term_produces_error(self):
+        curie = 'HP:0006010'  # obsolete Long fingers
         example_terms = list(self.example_terms)
-        example_terms.append(
-            MinimalTerm.create_minimal_term(
-                TermId.from_curie(query_id), name=name, alt_term_ids=[], is_obsolete=False)
-        )
+        example_terms.append(SimpleFeature(curie, True))
         results = self.validator.validate(example_terms)
         self.assertFalse(results.is_ok())
         self.assertEqual(results.results[0],
                          ValidationResult(level=ValidationLevel.WARNING, category='obsolete_term_id_is_used',
-                                          message=f'Using the obsolete {query_id} instead of {current_id} for {name}'))
+                                          message=f'Using the obsolete {curie} instead of '
+                                                  f'{self.o.get_term(curie).identifier.value} '
+                                                  f'for {self.o.get_term(curie).name}'))


### PR DESCRIPTION
The `hpo-toolkit` data model now includes new members to model observation status:
- `hpotk.model.ObservableFeature` - for annotations that can be present or excluded
- `hpotk.model.FrequencyAwareFeature` - for annotations derived from a cohort of items that include the *n/m* info (numerator and denominator). A child of `ObservableFeature`