### PR TITLE
Graph traversals fail if the query node does not exist in the graph

### DIFF
--- a/src/hpotk/graph/_api.py
+++ b/src/hpotk/graph/_api.py
@@ -31,6 +31,7 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
                      include_source: bool = False) -> typing.Iterable[NODE]:
         """
         Get an iterable with the children of the `source` node.
+        :raises ValueError: if `source` is not present in the graph.
         """
         pass
 
@@ -39,6 +40,7 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
                         include_source: bool = False) -> typing.Iterable[NODE]:
         """
         Get an iterable with the descendants of the `source` node.
+        :raises ValueError: if `source` is not present in the graph.
         """
         pass
 
@@ -47,6 +49,7 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
                     include_source: bool = False) -> typing.Iterable[NODE]:
         """
         Get an iterable with the parents of the `source` node.
+        :raises ValueError: if `source` is not present in the graph.
         """
         pass
 
@@ -55,12 +58,14 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
                       include_source: bool = False) -> typing.Iterable[NODE]:
         """
         Get an iterable with the ancestors of the `source` node.
+        :raises ValueError: if `source` is not present in the graph.
         """
         pass
 
     def is_leaf(self, node: typing.Union[str, NODE, Identified]) -> bool:
         """
         Return `True` if the `node` is a leaf node - a node with no descendants.
+        :raises ValueError: if `node` is not present in the graph.
         """
         for _ in self.get_descendants(node):
             return False
@@ -74,6 +79,7 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
         :param sub: a graph node.
         :param obj: other graph node.
         :return: `True` if the `sub` is a parent of the `obj`.
+        :raises ValueError: if `obj` is not present in the graph.
         """
         return self._run_query(self.get_parents, sub, obj)
 
@@ -85,6 +91,7 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
         :param sub: a graph node.
         :param obj: other graph node.
         :return: `True` if the `sub` is an ancestor of the `obj`.
+        :raises ValueError: if `obj` is not present in the graph.
         """
         return self._run_query(self.get_ancestors, sub, obj)
 
@@ -96,6 +103,7 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
         :param sub: a graph node.
         :param obj: other graph node.
         :return: `True` if the `sub` is a child of the `obj`.
+        :raises ValueError: if `obj` is not present in the graph.
         """
         return self._run_query(self.get_children, sub, obj)
 
@@ -107,6 +115,7 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
         :param sub: a graph node.
         :param obj: other graph node.
         :return: `True` if the `sub` is a descendant of the `obj`.
+        :raises ValueError: if `obj` is not present in the graph.
         """
         return self._run_query(self.get_descendants, sub, obj)
 

--- a/src/hpotk/graph/_csr_graph.py
+++ b/src/hpotk/graph/_csr_graph.py
@@ -99,6 +99,9 @@ class BaseCsrOntologyGraph(OntologyGraph, metaclass=abc.ABCMeta):
                                             include_source: bool) -> typing.Generator[int, None, None]:
         source: TermId = self._map_to_term_id(source)
         row_idx = self._get_idx_for_node(source)
+        if row_idx is None:
+            raise ValueError(f'Term ID not found in the graph: {source.value}')
+
         if include_source:
             yield row_idx
 

--- a/src/hpotk/graph/test__api.py
+++ b/src/hpotk/graph/test__api.py
@@ -174,6 +174,22 @@ class TestCsrOntologyGraph(unittest.TestCase):
         self.assertSetEqual(set(self.GRAPH.get_descendants('HP:01')),
                             {TermId.from_curie('HP:010'), TermId.from_curie('HP:011'), TermId.from_curie('HP:0110')})
 
+    @ddt.data(
+        ('is_parent_of',),
+        ('is_ancestor_of',),
+        ('is_child_of',),
+        ('is_descendant_of',),
+    )
+    @ddt.unpack
+    def test_query_methods_with_unknown_source(self, func_name):
+        existing = TermId.from_curie('HP:1')
+        unknown = TermId.from_curie('HP:999')
+
+        func = getattr(self.GRAPH, func_name)
+        with self.assertRaises(ValueError) as ctx:
+            func(existing, unknown)
+        self.assertEqual('Term ID not found in the graph: HP:999', ctx.exception.args[0])
+
 
 class SimpleIdentified(Identified):
 


### PR DESCRIPTION
Raise `ValueError` if the query `TermId` is not present in the graph.