### PR TITLE
Cache the hash of the `TermId`

### DIFF
--- a/src/hpotk/model/test__term_id.py
+++ b/src/hpotk/model/test__term_id.py
@@ -1,0 +1,46 @@
+import time
+import unittest
+
+import numpy as np
+
+from ._term_id import SimpleTermId, DefaultTermId
+
+
+@unittest.skip('The bench is not run routinely.')
+class TestTermIdBench(unittest.TestCase):
+    """
+    A naive benchmark to compare time required to create a set from different TermId implementations.
+    """
+
+    def test_bench_create_set(self):
+        n_iter = 10
+        n_elements = 10_000
+        n_concepts = 1_000_000
+
+        corpus = np.array(['HP:' + str(i).rjust(7, '0') for i in range(n_concepts)])
+        simple = np.fromiter(map(lambda curie: SimpleTermId(curie, 2), corpus), dtype=object)
+        default = np.fromiter(map(lambda curie: DefaultTermId(curie, 2), corpus), dtype=object)
+
+        simple_elapsed = []
+        default_elapsed = []
+        for _ in range(n_iter):
+            idx = np.random.choice(n_concepts, size=n_elements, replace=True)
+            simple_sel = simple[idx]
+            elapsed = time_it(set, simple_sel)
+            simple_elapsed.append(elapsed)
+
+            default_sel = default[idx]
+            elapsed = time_it(set, default_sel)
+            default_elapsed.append(elapsed)
+
+        s = np.array(simple_elapsed) / 1e6  # To convert to ms
+        d = np.array(default_elapsed) / 1e6  # To convert to ms
+
+        print(f'Simple: {s.mean():.3f} ±{s.std():.3f}ms')
+        print(f'Default: {d.mean():.3f} ±{d.std():.3f}ms')
+
+
+def time_it(f, *args):
+    start = time.time_ns()
+    f(*args)
+    return time.time_ns() - start

--- a/src/hpotk/ontology/load/obographs/_load.py
+++ b/src/hpotk/ontology/load/obographs/_load.py
@@ -41,16 +41,18 @@ def _load_impl(file: typing.Union[typing.IO, str],
     hpo = get_hpo_graph(file)
     logger.debug("Extracting ontology terms")
     id_to_term_id, terms = extract_terms(hpo['nodes'], term_factory)
-    logger.debug(f"Creating the edge list")
+    logger.debug("Creating the edge list")
     edge_list = create_edge_list(hpo['edges'], id_to_term_id)
-    logger.debug(f"Building ontology graph")
+    logger.debug("Building ontology graph")
     graph: OntologyGraph = graph_factory.create_graph(edge_list)
     if graph.root == OWL_THING:
         # TODO - consider adding Owl thing into terms list
         pass
     version = extract_ontology_version(hpo['meta'])
-    logger.debug(f"Assembling the ontology")
-    return ontology_creator(graph, terms, version)
+    logger.debug("Assembling the ontology")
+    ontology = ontology_creator(graph, terms, version)
+    logger.debug("Done")
+    return ontology
 
 
 def get_hpo_graph(file: typing.Union[typing.IO, str]):

--- a/src/hpotk/util.py
+++ b/src/hpotk/util.py
@@ -12,10 +12,10 @@ DEFAULT_LOG_FMT = '%(asctime)s %(name)-20s %(levelname)-3s : %(message)s'
 def setup_logging(level: int = logging.INFO,
                   log_fmt: str = DEFAULT_LOG_FMT):
     """
-        Create a basic configuration for the logging library. Set up console and file handler using provided `log_fmt`.
-        :param level: verbosity to use, INFO by default
-        :param log_fmt: format string for logging
-        """
+    Create a basic configuration for the logging library. Set up console and file handler using provided `log_fmt`.
+    :param level: verbosity to use, `20` (INFO) by default. Use `10` for DEBUG, `30` for `WARNING`, `40` for `ERROR`, and `50` for `CRITICAL`.
+    :param log_fmt: format string for logging
+    """
     # create logger
     logger = logging.getLogger()
     logger.setLevel(level)


### PR DESCRIPTION
Cache the `TermId`'s hash by default to improve performance of hash-dependent operations.