### PR TITLE
Require `numpy~=1.23.0` to support creating object arrays from iterables.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy >= 1.10"
+    "numpy >= 1.23"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
``np.fromiter`` only supports ``dtype=object`` from version ``1.23.0`` on (see https://numpy.org/doc/stable/reference/generated/numpy.fromiter.html). Without this requirement, an error is thrown when using ``hpotk.ontology.load.obographs.load_minimal_ontology(hpo_url)`` : ``ValueError: cannot create object arrays from iterator``