### PR TITLE
Add convenience method for getting term name

### DIFF
--- a/src/hpotk/model/__init__.py
+++ b/src/hpotk/model/__init__.py
@@ -11,10 +11,11 @@ from ._term import MinimalTerm, Term, Synonym, SynonymType, SynonymCategory
 # Types
 ID = typing.TypeVar('ID', bound=TermId)
 CURIE_OR_TERM_ID = typing.Union[str, ID]
+CURIE_OR_TERM_ID_OR_IDENTIFIED = typing.Union[str, TermId, Identified]
 MINIMAL_TERM = typing.TypeVar('MINIMAL_TERM', bound=MinimalTerm)
 TERM = typing.TypeVar('TERM', bound=Term)
 
 __all__ = ['TermId',
            'Identified', 'ObservableFeature', 'FrequencyAwareFeature', 'Named', 'Versioned', 'MetadataAware',
            'MinimalTerm', 'Term', 'Synonym', 'SynonymType', 'SynonymCategory',
-           'ID', 'CURIE_OR_TERM_ID', 'MINIMAL_TERM', 'TERM']
+           'ID', 'CURIE_OR_TERM_ID', 'CURIE_OR_TERM_ID_OR_IDENTIFIED', 'MINIMAL_TERM', 'TERM']

--- a/src/hpotk/model/_base.py
+++ b/src/hpotk/model/_base.py
@@ -56,7 +56,7 @@ class ObservableFeature(metaclass=abc.ABCMeta):
         """
         Test if the feature was not observed in any of the items.
 
-        :return: `True` if the feature was observed in *none of the annotated item(s), and was, therefore, excluded.
+        :return: `True` if the feature was observed in *none* of the annotated item(s), and was, therefore, excluded.
         """
         return not self.is_present
 

--- a/src/hpotk/ontology/_default.py
+++ b/src/hpotk/ontology/_default.py
@@ -2,9 +2,9 @@ import typing
 
 from hpotk.util import validate_instance, validate_optional_instance
 from hpotk.graph import OntologyGraph
-from hpotk.model import TermId
+from hpotk.model import TermId, Identified
 from ._api import Ontology, MinimalOntology
-from ._api import ID, MINIMAL_TERM, TERM, CURIE_OR_TERM_ID
+from ._api import ID, MINIMAL_TERM, TERM, CURIE_OR_TERM_ID_OR_IDENTIFIED
 
 
 class DefaultMinimalOntology(MinimalOntology[ID, MINIMAL_TERM]):
@@ -30,7 +30,7 @@ class DefaultMinimalOntology(MinimalOntology[ID, MINIMAL_TERM]):
     def terms(self) -> typing.Iterator[MINIMAL_TERM]:
         return iter(self._current_terms)
 
-    def get_term(self, term_id: CURIE_OR_TERM_ID) -> typing.Optional[MINIMAL_TERM]:
+    def get_term(self, term_id: CURIE_OR_TERM_ID_OR_IDENTIFIED) -> typing.Optional[MINIMAL_TERM]:
         term_id = _validate_term_id(term_id)
         try:
             return self._term_id_to_term[term_id]
@@ -68,7 +68,7 @@ class DefaultOntology(Ontology[ID, TERM]):
     def terms(self) -> typing.Iterator[TERM]:
         return iter(self._current_terms)
 
-    def get_term(self, term_id: ID) -> typing.Optional[TERM]:
+    def get_term(self, term_id: CURIE_OR_TERM_ID_OR_IDENTIFIED) -> typing.Optional[TERM]:
         term_id = _validate_term_id(term_id)
         try:
             return self._term_id_to_term[term_id]
@@ -130,13 +130,15 @@ def make_term_id_map(terms: typing.Sequence[MINIMAL_TERM]) -> typing.Mapping[ID,
     return data
 
 
-def _validate_term_id(term_id: CURIE_OR_TERM_ID) -> ID:
+def _validate_term_id(term_id: CURIE_OR_TERM_ID_OR_IDENTIFIED) -> TermId:
     """
     Validate that `term_id` is a `TermId` or a valid CURIE `str`.
     """
     if isinstance(term_id, TermId):
         return term_id
+    elif isinstance(term_id, Identified):
+        return term_id.identifier
     elif isinstance(term_id, str):
         return TermId.from_curie(term_id)
     else:
-        raise ValueError(f'Expected a `TermId` or a `str` but got {type(term_id)}')
+        raise ValueError(f'Expected a `str`, a `TermId` or an `Identified` entity but got {type(term_id)}')


### PR DESCRIPTION
Add convenience method for getting term name:

```python
hpo: MinimalOntology = ...
hpo.get_term_name('HP:0001250')
```
prints `Seizure`