### PR TITLE
Add `IndexedOntologyGraph`

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -27,7 +27,7 @@ jobs:
             python3 -m pip install .[test,docs]
         - name: Run tests
           run: |
-            pytest
+            pytest --import-mode=append
         - name: Run documentation tests
           run: |
             cd docs

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -27,7 +27,7 @@ jobs:
             python3 -m pip install .[test,docs]
         - name: Run tests
           run: |
-            pytest --import-mode=append
+            pytest
         - name: Run documentation tests
           run: |
             cd docs

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -24,7 +24,7 @@ jobs:
             python-version: ${{ matrix.python }}
         - name: Install hpo-toolkit
           run: |
-            python3 -m pip install .[test,docs]
+            python3 -m pip install --editable .[test,docs]
         - name: Run tests
           run: |
             pytest

--- a/benches/graph_traversal.py
+++ b/benches/graph_traversal.py
@@ -1,0 +1,157 @@
+import argparse
+import logging
+import sys
+import datetime
+import timeit
+import typing
+from collections import defaultdict
+
+import pandas as pd
+
+import hpotk
+
+hpotk.util.setup_logging()
+logger = logging.getLogger(__name__)
+
+COLUMNS = ('group', 'method', 'payload', 'throughput')
+
+# We'll bench traversals using these terms:
+CURIE2LABEL = {
+    'HP:0000118': 'Phenotypic abnormality',  # almost at the top of all terms
+    'HP:0001454': 'Abnormality of the upper arm',
+    'HP:0001166': 'Arachnodactyly',  # 2 parents
+    'HP:0001250': 'Seizure',
+    'HP:0009439': 'Short middle phalanx of the 3rd finger',  # 3 parents
+}
+
+
+def bench_func_throughput(func: typing.Callable[[], typing.Any],
+                          number: int) -> float:
+    # `timeit` returns the time it takes to execute the main statement a number of times,
+    # measured in seconds as a float.
+    cum_exec_time = timeit.timeit(func, number=number)
+    return number / cum_exec_time
+
+
+def bench_base_graph(fpath_hpo: str,
+                     number: int = 1000) -> typing.Mapping[str, typing.Sequence]:
+    factory = hpotk.graph.IncrementalCsrGraphFactory()
+    ontology = hpotk.load_minimal_ontology(fpath_hpo, graph_factory=factory)
+    graph = ontology.graph
+
+    results = defaultdict(list)
+
+    for curie, label in CURIE2LABEL.items():
+        term_id = hpotk.TermId.from_curie(curie)
+        label = ontology.get_term_name(curie)
+        payload = f'{label} [{curie}]'
+        logger.info('Timing %s', payload)
+
+        benches = {
+            'get_parents': lambda: list(graph.get_parents(term_id)),
+            'get_ancestors': lambda: list(graph.get_ancestors(term_id)),
+            'get_children': lambda: list(graph.get_children(term_id)),
+            'get_descendants': lambda: list(graph.get_descendants(term_id)),
+        }
+
+        for method in benches:
+            bench = benches[method]
+            logger.info(f' - {method}')
+            throughput = bench_func_throughput(bench, number)
+            results['method'].append(method)
+            results['payload'].append(payload)
+            results['throughput'].append(throughput)
+
+    return results
+
+
+def bench_indexed_graph(fpath_hpo: str,
+                        number: int = 1000) -> typing.Mapping[str, typing.Mapping[str, float]]:
+    factory = hpotk.graph.CsrIndexedGraphFactory()
+    ontology = hpotk.load_minimal_ontology(fpath_hpo, graph_factory=factory)
+    graph: hpotk.graph.IndexedOntologyGraph = ontology.graph
+
+    results = defaultdict(list)
+    for curie, label in CURIE2LABEL.items():
+        term_id = hpotk.TermId.from_curie(curie)
+        idx = graph.node_to_idx(term_id)
+        label = ontology.get_term_name(curie)
+        payload = f'{label} [{curie}]'
+        logger.info('Timing %s', payload)
+        benches = {
+            'get_parents_idx': lambda: list(graph.get_parents_idx(idx)),
+            'get_parents': lambda: list(graph.get_parents(term_id)),
+            'get_ancestor_idx': lambda: list(graph.get_ancestor_idx(idx)),
+            'get_ancestors': lambda: list(graph.get_ancestors(term_id)),
+            'get_children_idx': lambda: list(graph.get_children_idx(idx)),
+            'get_children': lambda: list(graph.get_children(term_id)),
+            'get_descendant_idx': lambda: list(graph.get_descendant_idx(idx)),
+            'get_descendants': lambda: list(graph.get_descendants(term_id)),
+        }
+
+        for method in benches:
+            bench = benches[method]
+            logger.info(f' - {method}')
+            throughput = bench_func_throughput(bench, number)
+            results['method'].append(method)
+            results['payload'].append(payload)
+            results['throughput'].append(throughput)
+
+    return results
+
+
+def bench(fpath_hpo: str, number: int, revision: str):
+    logger.info(f'Iterating {number:,d} times')
+
+    bench_groups = {
+        'IndexedOntologyGraph': bench_indexed_graph,
+        'OntologyGraph': bench_base_graph,
+    }
+
+    results = []
+    for group in bench_groups:
+        logger.info(f'Benching `{group}`')
+        bench_func = bench_groups[group]
+        data = bench_func(fpath_hpo, number=number)
+
+        result = pd.DataFrame(data)
+        result['group'] = group
+        results.append(result)
+
+
+    df = pd.concat(results)
+    df['revision'] = revision
+    df = df.set_index(['revision', 'method', 'group', 'payload']).sort_index()
+
+    fpath_df = f'graph_traversal-{number}-{revision}.csv'
+    df.to_csv(fpath_df)
+
+
+def main() -> int:
+    """
+    Benchmark graph traversals.
+    """
+    parser = argparse.ArgumentParser(prog='graph_traversal',
+                                     formatter_class=argparse.RawTextHelpFormatter,
+                                     description=main.__doc__)
+    parser.add_argument('--hpo', required=True, help='Path to HPO JSON file')
+    parser.add_argument('-n', '--number', default=1_000, help='Number of iterations of each bench')
+    parser.add_argument('-r', '--revision', default=None, help='The benchmark revision')
+
+    argv = sys.argv[1:]
+    if len(argv) == 0:
+        parser.print_help()
+        return 1
+
+    args = parser.parse_args(argv)
+    if args.revision is None:
+        revision = datetime.datetime.now().strftime('%Y-%m-%d')
+    else:
+        revision = args.revision
+    bench(args.hpo, args.number, revision)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -52,4 +52,27 @@ The documentation tests are run by::
 
   The library *must* be installed in the environment before running all tests. Otherwise, the test discovery will fail.
 
+Run benches
+^^^^^^^^^^^
+
+Bench suites provide an idea about the performance of the library.
+Running a bench requires checking out the GitHub repository and installing HPO toolkit with `bench` dependencies::
+
+  git clone https://github.com/TheJacksonLaboratory/hpo-toolkit.git
+  cd hpo-toolkit
+  python3 -m pip install .[bench]
+
+Then, running a bench suite is as easy as::
+
+  REVISION=$(git rev-parse --short HEAD)
+  python3 benches/graph_traversal.py --hpo /path/to/hp.json --revision ${REVISION}
+
+The `graph_traversal` bench suite measures mostly the graph traversal performance.
+The suite stores the bench results in a CSV file that is written into the current folder.
+The CSV file reports throughput (`ops/s`) of various methods.
+
+.. note::
+
+  The suite is under development and thus subject to change.
+
 That's about it!

--- a/docs/user-guide/use-hierarchy.rst
+++ b/docs/user-guide/use-hierarchy.rst
@@ -19,7 +19,7 @@ as a property:
   >>> import hpotk
   >>> hpo = hpotk.load_minimal_ontology('data/hp.toy.json')
   >>> hpo.graph
-  BaseCsrOntologyGraph(root=HP:0000001, n_nodes=393)
+  CsrIndexedOntologyGraph(root=HP:0000001, n_nodes=393)
 
 
 We can leverage the hierarchy to infer a lot of extra information about the concepts, and, for instance,
@@ -52,8 +52,9 @@ We can get term IDs of the *parents* of a term, such as `Seizure <https://hpo.ja
 
   >>> for child in hpo.graph.get_children('HP:0001250'):
   ...   print(child)
-  HP:0007359
   HP:0020219
+  HP:0007359
+
 
 We will leave finding the ancestors or descendants of a term as an exercise for the interested reader.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest>=7.0.0, <8.0.0",
+    "pytest>=8.0.0, <9.0.0",
     "ddt >= 1.6.0",  # TODO: remove after finishing the migration to `pytest`!
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,15 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest>=7.0.0, <=8.0.0",
-    "ddt >= 1.6.0"  # TODO: remove after finishing the migration to `pytest`!
+    "pytest>=7.0.0, <8.0.0",
+    "ddt >= 1.6.0",  # TODO: remove after finishing the migration to `pytest`!
 ]
-docs = ["sphinx>=7.0.0", "sphinx-copybutton>=0.5.0", "sphinx-rtd-theme>=1.3.0"]
+docs = [
+    "sphinx>=7.0.0", "sphinx-copybutton>=0.5.0", "sphinx-rtd-theme>=1.3.0",
+]
+bench = [
+    'pandas >= 1.0.0, <3.0',
+]
 
 [project.urls]
 "Repository" = "https://github.com/TheJacksonLaboratory/hpo-toolkit"

--- a/src/hpotk/graph/__init__.py
+++ b/src/hpotk/graph/__init__.py
@@ -1,7 +1,10 @@
-from ._api import OntologyGraph, GraphAware, OWL_THING
+from ._api import OntologyGraph, IndexedOntologyGraph, GraphAware, OWL_THING
 from ._csr_graph import SimpleCsrOntologyGraph  # REMOVE(v1.0.0)
 from ._factory import CsrGraphFactory  # REMOVE(v1.0.0)
-from ._factory import GraphFactory, IncrementalCsrGraphFactory
+from ._factory import GraphFactory, IncrementalCsrGraphFactory, CsrIndexedGraphFactory
 
-__all__ = ['OntologyGraph', 'GraphAware',
-           'GraphFactory', 'IncrementalCsrGraphFactory']
+__all__ = [
+    'OntologyGraph', 'IndexedOntologyGraph',
+    'GraphFactory', 'IncrementalCsrGraphFactory', 'CsrIndexedGraphFactory',
+    'GraphAware',
+]

--- a/src/hpotk/graph/_csr_idx_graph.py
+++ b/src/hpotk/graph/_csr_idx_graph.py
@@ -1,0 +1,99 @@
+import typing
+
+import numpy as np
+
+import hpotk
+from ._api import IndexedOntologyGraph, NODE
+
+
+class StaticCsrArray:
+
+    def __init__(self, indptr: typing.Sequence[int],
+                 data: typing.Sequence[int]):
+        self._indptr = np.array(indptr)
+        self._data = np.array(data)
+        self._max_row = len(self._indptr)
+
+    def outgoing_nodes(self, row: int) -> typing.Sequence[int]:
+        if row < 0 or self._max_row < row:
+            raise ValueError(f'No such row {row}')
+
+        start = self._indptr[row]
+        end = self._indptr[row + 1]
+
+        # TODO: maybe we can test if start==end and return a tuple if yes
+        return self._data[start: end]
+
+
+class CsrData:
+
+    def __init__(self, children: StaticCsrArray,
+                 parents: StaticCsrArray):
+        self._children = children
+        self._parents = parents
+
+    @property
+    def children(self) -> StaticCsrArray:
+        return self._children
+
+    @property
+    def parents(self) -> StaticCsrArray:
+        return self._parents
+
+
+class CsrIndexedOntologyGraph(IndexedOntologyGraph):
+
+    def __init__(self, root: int,
+                 nodes: typing.Sequence[NODE],
+                 csr_data: CsrData):
+        self._root = hpotk.util.validate_instance(root, int, 'root')
+        self._nodes = np.array(nodes)
+        self._node_to_idx = {node: i for i, node in enumerate(self._nodes)}
+        self._csr_data = hpotk.util.validate_instance(csr_data, CsrData, 'csr_data')
+
+    @property
+    def root_idx(self) -> int:
+        return self._root
+
+    def get_children_idx(self, source: int) -> typing.Sequence[int]:
+        return self._csr_data.children.outgoing_nodes(source)
+
+    def get_descendant_idx(self, source: int) -> typing.Iterator[int]:
+        return self._traverse_graph(source, self.get_children_idx)
+
+    def get_parents_idx(self, source: int) -> typing.Sequence[int]:
+        return self._csr_data.parents.outgoing_nodes(source)
+
+    def get_ancestor_idx(self, source: int) -> typing.Iterator[int]:
+        return self._traverse_graph(source, self.get_parents_idx)
+
+    def idx_to_node(self, idx: int) -> NODE:
+        return self._nodes[idx]
+
+    def node_to_idx(self, node: NODE) -> typing.Optional[int]:
+        try:
+            return self._node_to_idx[node]
+        except KeyError:
+            return None
+
+    def __iter__(self) -> typing.Iterator[NODE]:
+        return iter(self._nodes)
+
+    @staticmethod
+    def _traverse_graph(source: int,
+                        supplier: typing.Callable[[int], typing.Sequence[int]]) -> typing.Generator[int, None, None]:
+        seen = set()
+        buffer = []
+
+        for idx in supplier(source):
+            seen.add(idx)
+            buffer.append(idx)
+
+        while buffer:
+            current = buffer.pop()
+            for idx in supplier(current):
+                if idx not in seen:
+                    seen.add(idx)
+                    buffer.append(idx)
+
+            yield current

--- a/src/hpotk/graph/_csr_idx_graph.py
+++ b/src/hpotk/graph/_csr_idx_graph.py
@@ -97,3 +97,6 @@ class CsrIndexedOntologyGraph(IndexedOntologyGraph):
                     buffer.append(idx)
 
             yield current
+
+    def __repr__(self):
+        return f"CsrIndexedOntologyGraph(root={self.idx_to_node(self._root)}, n_nodes={len(self._nodes)})"

--- a/src/hpotk/graph/_test_csr_idx_graph.py
+++ b/src/hpotk/graph/_test_csr_idx_graph.py
@@ -1,0 +1,153 @@
+import typing
+
+import pytest
+
+import hpotk
+from ._csr_idx_graph import CsrIndexedOntologyGraph
+from ._factory import CsrIndexedGraphFactory
+
+
+@pytest.fixture
+def edges() -> typing.Sequence[typing.Tuple[hpotk.TermId, hpotk.TermId]]:
+    # Edges for a graph with a single root node: HP:1
+    return (
+        # source -> destination
+        (hpotk.TermId.from_curie('HP:01'), hpotk.TermId.from_curie('HP:1')),
+        (hpotk.TermId.from_curie('HP:010'), hpotk.TermId.from_curie('HP:01')),
+        (hpotk.TermId.from_curie('HP:011'), hpotk.TermId.from_curie('HP:01')),
+        # This one is multi-parent.
+        (hpotk.TermId.from_curie('HP:0110'), hpotk.TermId.from_curie('HP:010')),
+        (hpotk.TermId.from_curie('HP:0110'), hpotk.TermId.from_curie('HP:011')),
+
+        (hpotk.TermId.from_curie('HP:02'), hpotk.TermId.from_curie('HP:1')),
+        (hpotk.TermId.from_curie('HP:020'), hpotk.TermId.from_curie('HP:02')),
+        (hpotk.TermId.from_curie('HP:021'), hpotk.TermId.from_curie('HP:02')),
+        (hpotk.TermId.from_curie('HP:022'), hpotk.TermId.from_curie('HP:02')),
+
+        (hpotk.TermId.from_curie('HP:03'), hpotk.TermId.from_curie('HP:1')),
+    )
+
+
+class TestCsrIndexedOntologyGraph:
+    """
+    Assuming `CsrIndexedGraphFactory` is correct, here we test the HPO traversal and others.
+    """
+
+    @pytest.fixture
+    def graph(self, edges: typing.Sequence[typing.Tuple[hpotk.TermId, hpotk.TermId]]) -> CsrIndexedOntologyGraph:
+        factory = CsrIndexedGraphFactory()
+        return factory.create_graph(edges)
+
+    def test_root(self, graph: CsrIndexedOntologyGraph):
+        assert graph.root == hpotk.TermId.from_curie('HP:1')
+
+    @pytest.mark.parametrize(
+        'source, expected',
+        [
+            ("HP:1", {"HP:01", "HP:02", "HP:03"}),
+            ("HP:01", {"HP:010", "HP:011"}),
+            ("HP:010", {"HP:0110"}),
+            ("HP:011", {"HP:0110"}),
+            ("HP:0110", {}),
+
+            ("HP:02", {"HP:020", "HP:021", "HP:022"}),
+
+            ("HP:03", {}),
+        ]
+    )
+    def test_get_children(self, graph: CsrIndexedOntologyGraph,
+                          source: str, expected: typing.Set[str]):
+        actual = set(graph.get_children(hpotk.TermId.from_curie(source)))
+
+        assert actual == set(hpotk.TermId.from_curie(curie) for curie in expected)
+
+    @pytest.mark.parametrize(
+        'source, expected',
+        [
+            ("HP:1", {"HP:01", "HP:010", "HP:011", "HP:0110", "HP:02", "HP:020", "HP:021", "HP:022", "HP:03"}),
+            ("HP:01", {"HP:010", "HP:011", "HP:0110"}),
+            ("HP:010", {"HP:0110"}),
+            ("HP:011", {"HP:0110"}),
+            ("HP:0110", {}),
+
+            ("HP:02", {"HP:020", "HP:021", "HP:022"}),
+
+            ("HP:03", {}),
+        ]
+    )
+    def test_get_descendants(self, graph: CsrIndexedOntologyGraph,
+                             source: str, expected: typing.Set[str]):
+        actual = set(graph.get_descendants(hpotk.TermId.from_curie(source)))
+
+        assert actual == set(hpotk.TermId.from_curie(curie) for curie in expected)
+
+    @pytest.mark.parametrize(
+        'source, expected',
+        [
+            ("HP:1", {"HP:01", "HP:010", "HP:011", "HP:0110", "HP:02", "HP:020", "HP:021", "HP:022", "HP:03", "HP:1"}),
+            ("HP:01", {"HP:010", "HP:011", "HP:0110", "HP:01"}),
+            ("HP:010", {"HP:0110", "HP:010"}),
+            ("HP:011", {"HP:0110", "HP:011"}),
+            ("HP:0110", {"HP:0110"}),
+
+            ("HP:02", {"HP:020", "HP:021", "HP:022", "HP:02"}),
+
+            ("HP:03", {"HP:03"}),
+        ]
+    )
+    def test_get_descendants_incl_source(self, graph: CsrIndexedOntologyGraph,
+                                         source: str, expected: typing.Set[str]):
+        actual = set(graph.get_descendants(hpotk.TermId.from_curie(source), include_source=True))
+
+        assert actual == set(hpotk.TermId.from_curie(curie) for curie in expected)
+
+    @pytest.mark.parametrize(
+        'source, expected',
+        [
+            ("HP:1", {}),
+            ("HP:01", {"HP:1"}),
+            ("HP:010", {"HP:01"}),
+            ("HP:0110", {"HP:010", "HP:011"}),
+
+            ("HP:03", {"HP:1"}),
+        ]
+    )
+    def test_get_parents(self, graph: CsrIndexedOntologyGraph,
+                         source: str, expected: typing.Set[str]):
+        actual = set(graph.get_parents(hpotk.TermId.from_curie(source)))
+
+        assert actual == set(hpotk.TermId.from_curie(curie) for curie in expected)
+
+    @pytest.mark.parametrize(
+        'source, expected',
+        [
+            ("HP:1", {}),
+            ("HP:01", {"HP:1"}),
+            ("HP:010", {"HP:1", "HP:01"}),
+            ("HP:0110", {"HP:1", "HP:01", "HP:010", "HP:011"}),
+
+            ("HP:03", {"HP:1"}),
+        ]
+    )
+    def test_get_ancestors(self, graph: CsrIndexedOntologyGraph,
+                           source: str, expected: typing.Set[str]):
+        actual = set(graph.get_ancestors(hpotk.TermId.from_curie(source)))
+
+        assert actual == set(hpotk.TermId.from_curie(curie) for curie in expected)
+
+    @pytest.mark.parametrize(
+        'source, expected',
+        [
+            ("HP:1", {"HP:1"}),
+            ("HP:01", {"HP:1", "HP:01"}),
+            ("HP:010", {"HP:1", "HP:01", "HP:010"}),
+            ("HP:0110", {"HP:1", "HP:01", "HP:010", "HP:011", "HP:0110"}),
+
+            ("HP:03", {"HP:1", "HP:03"}),
+        ]
+    )
+    def test_get_ancestors_incl_source(self, graph: CsrIndexedOntologyGraph,
+                                       source: str, expected: typing.Set[str]):
+        actual = set(graph.get_ancestors(hpotk.TermId.from_curie(source), include_source=True))
+
+        assert actual == set(hpotk.TermId.from_curie(curie) for curie in expected)

--- a/src/hpotk/ontology/load/obographs/_load.py
+++ b/src/hpotk/ontology/load/obographs/_load.py
@@ -5,7 +5,7 @@ import logging
 
 from hpotk.model import TermId, MinimalTerm, Term
 from hpotk.graph import OntologyGraph
-from hpotk.graph import GraphFactory, IncrementalCsrGraphFactory, OWL_THING
+from hpotk.graph import GraphFactory, CsrIndexedGraphFactory, OWL_THING
 from hpotk.ontology import MinimalOntology, Ontology, create_ontology, create_minimal_ontology
 from hpotk.util import open_text_io_handle_for_reading
 
@@ -24,13 +24,13 @@ DATE_PATTERN = re.compile(r'.*/(?P<date>\d{4}-\d{2}-\d{2})/.*')
 
 def load_minimal_ontology(file: typing.Union[typing.IO, str],
                           term_factory: ObographsTermFactory[MinimalTerm] = MinimalTermFactory(),
-                          graph_factory: GraphFactory = IncrementalCsrGraphFactory()) -> MinimalOntology:
+                          graph_factory: GraphFactory = CsrIndexedGraphFactory()) -> MinimalOntology:
     return _load_impl(file, term_factory, graph_factory, create_minimal_ontology)
 
 
 def load_ontology(file: typing.Union[typing.IO, str],
                   term_factory: ObographsTermFactory[Term] = TermFactory(),
-                  graph_factory: GraphFactory = IncrementalCsrGraphFactory()) -> Ontology:
+                  graph_factory: GraphFactory = CsrIndexedGraphFactory()) -> Ontology:
     return _load_impl(file, term_factory, graph_factory, create_ontology)
 
 

--- a/tests/algorithm/test_similarity.py
+++ b/tests/algorithm/test_similarity.py
@@ -1,41 +1,28 @@
-import os
-
 import pytest
-from pkg_resources import resource_filename
 
 import hpotk
 from hpotk.algorithm.similarity import calculate_ic_for_annotated_items, precalculate_ic_mica_for_hpo_concept_pairs
-
-from hpotk.model import TermId
 from hpotk.annotations.load.hpoa import SimpleHpoaDiseaseLoader
-from hpotk.ontology.load.obographs import load_minimal_ontology
-
-TOY_HPO = resource_filename(__name__, os.path.join('../data', 'hp.small.json'))
-# TOY_HPO = '/home/ielis/data/ontologies/hpo/2023-04-05/hp.2023-04-05.json'
-TOY_HPOA = resource_filename(__name__, os.path.join('../data', 'phenotype.real-shortlist.hpoa'))
-# TOY_HPOA = '/home/ielis/data/hpoa/phenotype.2023-04-05.hpoa'
+from hpotk.model import TermId
 
 
 class TestResnik:
 
     @pytest.fixture(scope='class')
-    def toy_hpo(self) -> hpotk.MinimalOntology:
-        return load_minimal_ontology(TOY_HPO)
-
-    @pytest.fixture(scope='class')
-    def toy_hpoa(self, toy_hpo: hpotk.MinimalOntology) -> hpotk.annotations.HpoDiseases:
-        hpoa_loader = SimpleHpoaDiseaseLoader(toy_hpo)
-        return hpoa_loader.load(TOY_HPOA)
+    def toy_hpoa(self, small_hpo: hpotk.MinimalOntology,
+                 fpath_real_shortlist_hpoa: str) -> hpotk.annotations.HpoDiseases:
+        hpoa_loader = SimpleHpoaDiseaseLoader(small_hpo)
+        return hpoa_loader.load(fpath_real_shortlist_hpoa)
 
     @pytest.mark.skip('Skipped for now')
-    def test_precalculate_and_store(self, toy_hpo: hpotk.MinimalOntology,
+    def test_precalculate_and_store(self, small_hpo: hpotk.MinimalOntology,
                                     toy_hpoa: hpotk.annotations.HpoDiseases):
-        mica = calculate_ic_for_annotated_items(toy_hpoa, toy_hpo)
+        mica = calculate_ic_for_annotated_items(toy_hpoa, small_hpo)
         mica.to_csv('ic.csv.gz')
 
-    def test_calculate_ic_for_hpo_diseases(self, toy_hpo: hpotk.MinimalOntology,
+    def test_calculate_ic_for_hpo_diseases(self, small_hpo: hpotk.MinimalOntology,
                                            toy_hpoa: hpotk.annotations.HpoDiseases):
-        container = calculate_ic_for_annotated_items(toy_hpoa, toy_hpo)
+        container = calculate_ic_for_annotated_items(toy_hpoa, small_hpo)
 
         expected = {
             # All the way down to Arachnodactyly
@@ -64,65 +51,65 @@ class TestResnik:
         # Hence, it is not in the `container`
         assert TermId.from_curie('HP:0000160') not in container
         # With the current `self.DISEASES`, the items are not annotated with all ontology terms.
-        assert len(toy_hpo) != len(container)
+        assert len(small_hpo) != len(container)
 
-    def test_calculate_ic_for_hpo_diseases__use_pseudocount(self, toy_hpo: hpotk.MinimalOntology,
+    def test_calculate_ic_for_hpo_diseases__use_pseudocount(self, small_hpo: hpotk.MinimalOntology,
                                                             toy_hpoa: hpotk.annotations.HpoDiseases):
-        container = calculate_ic_for_annotated_items(toy_hpoa, toy_hpo, use_pseudocount=True)
+        container = calculate_ic_for_annotated_items(toy_hpoa, small_hpo, use_pseudocount=True)
 
-        assert len(toy_hpo) == len(container)
+        assert len(small_hpo) == len(container)
 
         # HP:0000160 Narrow mouth does not annotate any items from self.DISEASES.
         # Yet, as a result of `use_pseudocount`, we have an IC value.
         assert 4.406719247264253 == pytest.approx(container[TermId.from_curie('HP:0000160')])
         # Similarly, we have IC for ALL ontology terms
-        assert len(toy_hpo) == len(container)
+        assert len(small_hpo) == len(container)
 
-    def test_calculate_ic_for_hpo_diseases__submodule(self, toy_hpo: hpotk.MinimalOntology,
+    def test_calculate_ic_for_hpo_diseases__submodule(self, small_hpo: hpotk.MinimalOntology,
                                                       toy_hpoa: hpotk.annotations.HpoDiseases):
         module_root = TermId.from_curie('HP:0012372')  # Abnormal eye morphology
-        container = calculate_ic_for_annotated_items(toy_hpoa, toy_hpo, module_root=module_root)
+        container = calculate_ic_for_annotated_items(toy_hpoa, small_hpo, module_root=module_root)
 
         # The IC of the module root is 0.
         assert 0. == pytest.approx(container[module_root])
 
         # All container elements are descendants (incl) of the module root.
-        descendants = set(toy_hpo.graph.get_descendants(module_root, include_source=True))
+        descendants = set(small_hpo.graph.get_descendants(module_root, include_source=True))
         assert all(term_id in descendants for term_id in container.keys())
 
         # We do not have IC for terms that are not descendants of the module root
-        all_term_ids = set(map(lambda t: t.identifier, toy_hpo.terms))
+        all_term_ids = set(map(lambda t: t.identifier, small_hpo.terms))
         others = all_term_ids.difference(descendants)
         assert not any(other in container for other in others)
 
-    def test_calculate_ic_for_hpo_diseases__submodule_and_use_pseudocount(self, toy_hpo: hpotk.MinimalOntology,
+    def test_calculate_ic_for_hpo_diseases__submodule_and_use_pseudocount(self, small_hpo: hpotk.MinimalOntology,
                                                                           toy_hpoa: hpotk.annotations.HpoDiseases):
         module_root = TermId.from_curie('HP:0012372')  # Abnormal eye morphology
-        container = calculate_ic_for_annotated_items(toy_hpoa, toy_hpo,
+        container = calculate_ic_for_annotated_items(toy_hpoa, small_hpo,
                                                      module_root=module_root, use_pseudocount=True)
 
         # The IC of the module root is 0.
         assert 0. == pytest.approx(container[module_root])
 
         # All container elements are descendants (incl) of the module root.
-        descendants = set(toy_hpo.graph.get_descendants(module_root, include_source=True))
+        descendants = set(small_hpo.graph.get_descendants(module_root, include_source=True))
         assert all(term_id in descendants for term_id in container.keys())
 
         # We have IC for all descendants
         assert all(term_id in container for term_id in descendants)
 
         # We do not have IC for terms that are not descendants of the module root
-        all_term_ids = set(map(lambda t: t.identifier, toy_hpo.terms))
+        all_term_ids = set(map(lambda t: t.identifier, small_hpo.terms))
         others = all_term_ids.difference(descendants)
         assert not any(other in container for other in others)
 
     @pytest.mark.skip('Skipped for now')
-    def test_precalculate_mica_for_hpo_concept_pairs(self, toy_hpo: hpotk.MinimalOntology,
+    def test_precalculate_mica_for_hpo_concept_pairs(self, small_hpo: hpotk.MinimalOntology,
                                                      toy_hpoa: hpotk.annotations.HpoDiseases):
         # Takes ~15 seconds, and it isn't run regularly.
-        term_id2ic = calculate_ic_for_annotated_items(toy_hpoa, toy_hpo)
+        term_id2ic = calculate_ic_for_annotated_items(toy_hpoa, small_hpo)
 
-        sim_container = precalculate_ic_mica_for_hpo_concept_pairs(term_id2ic, toy_hpo)
+        sim_container = precalculate_ic_mica_for_hpo_concept_pairs(term_id2ic, small_hpo)
 
         assert sim_container.get_similarity('HP:0000118', 'HP:0000118'), pytest.approx(0.)  # Phenotypic abnormality
 

--- a/tests/algorithm/test_traversal.py
+++ b/tests/algorithm/test_traversal.py
@@ -1,20 +1,9 @@
-import os
-
 import pytest
-from pkg_resources import resource_filename
 
 import hpotk
-from hpotk.model import TermId
-from hpotk.ontology.load.obographs import load_minimal_ontology
-
-TOY_HPO = resource_filename(__name__, os.path.join('../data', 'hp.toy.json'))
 
 
 class TestTraversal:
-
-    @pytest.fixture(scope='class')
-    def toy_hpo(self) -> hpotk.MinimalOntology:
-        return load_minimal_ontology(TOY_HPO)
 
     @pytest.mark.parametrize('source, include_source, expected',
                              [
@@ -23,7 +12,7 @@ class TestTraversal:
                              ])
     def test_get_parents(self, source: str, include_source, expected, toy_hpo: hpotk.MinimalOntology):
         parents = set(toy_hpo.graph.get_parents(source, include_source))
-        assert parents == {TermId.from_curie(val) for val in expected}
+        assert parents == {hpotk.TermId.from_curie(val) for val in expected}
 
     @pytest.mark.parametrize('source, include_source, expected',
                              [("HP:0001166", False,
@@ -42,7 +31,7 @@ class TestTraversal:
                                })])
     def test_get_ancestors(self, source: str, include_source, expected, toy_hpo: hpotk.MinimalOntology):
         ancestors = set(toy_hpo.graph.get_ancestors(source, include_source))
-        assert ancestors == {TermId.from_curie(val) for val in expected}
+        assert ancestors == {hpotk.TermId.from_curie(val) for val in expected}
 
     @pytest.mark.parametrize('source, include_source, expected',
                              [
@@ -51,7 +40,7 @@ class TestTraversal:
                              ])
     def test_get_children(self, source: str, include_source, expected, toy_hpo: hpotk.MinimalOntology):
         children = set(toy_hpo.graph.get_children(source, include_source))
-        assert children == {TermId.from_curie(val) for val in expected}
+        assert children == {hpotk.TermId.from_curie(val) for val in expected}
 
     @pytest.mark.parametrize('source, include_source, expected',
                              [
@@ -60,7 +49,7 @@ class TestTraversal:
                              ])
     def test_get_descendants(self, source: str, include_source, expected, toy_hpo: hpotk.MinimalOntology):
         descendants = set(toy_hpo.graph.get_descendants(source, include_source))
-        assert descendants == {TermId.from_curie(val) for val in expected}
+        assert descendants == {hpotk.TermId.from_curie(val) for val in expected}
 
     def test_we_get_correct_number_of_descendants(self, toy_hpo: hpotk.MinimalOntology):
         all_term_id = "HP:0000001"

--- a/tests/annotations/load/test_hpoa.py
+++ b/tests/annotations/load/test_hpoa.py
@@ -1,21 +1,11 @@
-import os
 import typing
 
 import pytest
 
 import hpotk
-from pkg_resources import resource_filename
-
-TOY_HPO = resource_filename(__name__, os.path.join('../../data', 'hp.toy.json'))
-TOY_HPOA_OLDER = resource_filename(__name__, os.path.join('../../data', 'phenotype.fake.older.hpoa'))
-TOY_HPOA = resource_filename(__name__, os.path.join('../../data', 'phenotype.fake.novel.hpoa'))
 
 
 class TestHpoaLoaderBase:
-
-    @pytest.fixture
-    def toy_hpo(self) -> hpotk.MinimalOntology:
-        return hpotk.load_minimal_ontology(TOY_HPO)
 
     @pytest.fixture
     def loader(self, toy_hpo: hpotk.MinimalOntology) -> hpotk.annotations.load.hpoa.SimpleHpoaDiseaseLoader:
@@ -24,16 +14,18 @@ class TestHpoaLoaderBase:
 
 class TestHpoaLoader(TestHpoaLoaderBase):
 
-    def test_load_hpo_annotations(self, loader: hpotk.annotations.load.hpoa.SimpleHpoaDiseaseLoader):
-        diseases = loader.load(TOY_HPOA)
+    def test_load_hpo_annotations(self, loader: hpotk.annotations.load.hpoa.SimpleHpoaDiseaseLoader,
+                                  fpath_toy_hpoa: str):
+        diseases = loader.load(fpath_toy_hpoa)
         assert isinstance(diseases, hpotk.annotations.HpoDiseases)
 
         assert 2 == len(diseases)
         assert {'ORPHA:123456', 'OMIM:987654'} == set(map(lambda di: di.value, diseases.item_ids()))
         assert diseases.version == '2021-08-02'
 
-    def test_load_older_hpo_annotations(self, loader: hpotk.annotations.load.hpoa.SimpleHpoaDiseaseLoader):
-        diseases = loader.load(TOY_HPOA_OLDER)
+    def test_load_older_hpo_annotations(self, loader: hpotk.annotations.load.hpoa.SimpleHpoaDiseaseLoader,
+                                        fpath_toy_hpoa_older: str):
+        diseases = loader.load(fpath_toy_hpoa_older)
         assert isinstance(diseases, hpotk.annotations.HpoDiseases)
 
         assert 2 == len(diseases)
@@ -44,8 +36,9 @@ class TestHpoaDiseaseProperties(TestHpoaLoaderBase):
 
     @pytest.fixture
     def toy_hpo_diseases(self,
-                         loader: hpotk.annotations.load.hpoa.SimpleHpoaDiseaseLoader) -> hpotk.annotations.HpoDiseases:
-        return loader.load(TOY_HPOA)
+                         loader: hpotk.annotations.load.hpoa.SimpleHpoaDiseaseLoader,
+                         fpath_toy_hpoa: str) -> hpotk.annotations.HpoDiseases:
+        return loader.load(fpath_toy_hpoa)
 
     def test_hpoa_disease_properties(self, toy_hpo_diseases: hpotk.annotations.HpoDiseases,
                                      loader: hpotk.annotations.load.hpoa.SimpleHpoaDiseaseLoader):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+
+import pytest
+import hpotk
+
+from pkg_resources import resource_filename
+
+TOY_HPO = resource_filename(__name__, os.path.join('data', 'hp.toy.json'))
+
+
+@pytest.fixture(scope='session')
+def toy_hpo() -> hpotk.Ontology:
+    return hpotk.load_ontology(TOY_HPO)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,22 +3,26 @@ import os
 import pytest
 import hpotk
 
-from pkg_resources import resource_filename
+
+@pytest.fixture(scope='session')
+def fpath_data() -> str:
+    parent = os.path.dirname(__file__)
+    return os.path.join(parent, 'data')
 
 
 @pytest.fixture(scope='session')
-def fpath_toy_hpo() -> str:
-    return resource_filename(__name__, os.path.join('data', 'hp.toy.json'))
+def fpath_toy_hpo(fpath_data: str) -> str:
+    return os.path.join(fpath_data, 'hp.toy.json')
 
 
 @pytest.fixture(scope='session')
-def fpath_toy_hpoa_older() -> str:
-    return resource_filename(__name__, os.path.join('data', 'phenotype.fake.older.hpoa'))
+def fpath_toy_hpoa_older(fpath_data: str) -> str:
+    return os.path.join(fpath_data, 'phenotype.fake.older.hpoa')
 
 
 @pytest.fixture(scope='session')
-def fpath_toy_hpoa() -> str:
-    return resource_filename(__name__, os.path.join('data', 'phenotype.fake.novel.hpoa'))
+def fpath_toy_hpoa(fpath_data: str) -> str:
+    return os.path.join(fpath_data, 'phenotype.fake.novel.hpoa')
 
 
 @pytest.fixture(scope='session')
@@ -27,8 +31,8 @@ def toy_hpo(fpath_toy_hpo: str) -> hpotk.Ontology:
 
 
 @pytest.fixture(scope='session')
-def fpath_small_hpo() -> str:
-    return resource_filename(__name__, os.path.join('data', 'hp.small.json'))
+def fpath_small_hpo(fpath_data: str) -> str:
+    return os.path.join(fpath_data, 'hp.small.json')
 
 
 @pytest.fixture(scope='session')
@@ -37,6 +41,5 @@ def small_hpo(fpath_small_hpo: str) -> hpotk.Ontology:
 
 
 @pytest.fixture(scope='session')
-def fpath_real_shortlist_hpoa() -> str:
-    return resource_filename(__name__, os.path.join('data', 'phenotype.real-shortlist.hpoa'))
-
+def fpath_real_shortlist_hpoa(fpath_data: str) -> str:
+    return os.path.join(fpath_data, 'phenotype.real-shortlist.hpoa')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,38 @@ import hpotk
 
 from pkg_resources import resource_filename
 
-TOY_HPO = resource_filename(__name__, os.path.join('data', 'hp.toy.json'))
+
+@pytest.fixture(scope='session')
+def fpath_toy_hpo() -> str:
+    return resource_filename(__name__, os.path.join('data', 'hp.toy.json'))
 
 
 @pytest.fixture(scope='session')
-def toy_hpo() -> hpotk.Ontology:
-    return hpotk.load_ontology(TOY_HPO)
+def fpath_toy_hpoa_older() -> str:
+    return resource_filename(__name__, os.path.join('data', 'phenotype.fake.older.hpoa'))
+
+
+@pytest.fixture(scope='session')
+def fpath_toy_hpoa() -> str:
+    return resource_filename(__name__, os.path.join('data', 'phenotype.fake.novel.hpoa'))
+
+
+@pytest.fixture(scope='session')
+def toy_hpo(fpath_toy_hpo: str) -> hpotk.Ontology:
+    return hpotk.load_ontology(fpath_toy_hpo)
+
+
+@pytest.fixture(scope='session')
+def fpath_small_hpo() -> str:
+    return resource_filename(__name__, os.path.join('data', 'hp.small.json'))
+
+
+@pytest.fixture(scope='session')
+def small_hpo(fpath_small_hpo: str) -> hpotk.Ontology:
+    return hpotk.load_ontology(fpath_small_hpo)
+
+
+@pytest.fixture(scope='session')
+def fpath_real_shortlist_hpoa() -> str:
+    return resource_filename(__name__, os.path.join('data', 'phenotype.real-shortlist.hpoa'))
+

--- a/tests/ontology/load/test_obographs.py
+++ b/tests/ontology/load/test_obographs.py
@@ -1,22 +1,17 @@
-import os
-
 import pytest
-from pkg_resources import resource_filename
 
 import hpotk
 import hpotk as hp
 from hpotk.model import TermId
 from hpotk.ontology.load.obographs import *
 
-TOY_HPO = resource_filename(__name__, os.path.join('../../data', 'hp.toy.json'))
-
 hp.util.setup_logging()
 
 
 class TestLoad:
 
-    def test_load_minimal_ontology(self):
-        o: hp.ontology.MinimalOntology = load_minimal_ontology(TOY_HPO)
+    def test_load_minimal_ontology(self, fpath_toy_hpo: str):
+        o: hp.ontology.MinimalOntology = load_minimal_ontology(fpath_toy_hpo)
 
         assert o is not None, "Ontology must not be None"
         assert isinstance(o, hp.ontology.MinimalOntology)
@@ -32,8 +27,8 @@ class TestLoad:
         assert all([o.get_term(k).identifier == k or k in o.get_term(k).alt_term_ids for k in o.term_ids]), \
             "Each term ID must be either primary or alternative ID"
 
-    def test_load_ontology(self):
-        o: hp.ontology.Ontology = load_ontology(TOY_HPO)
+    def test_load_ontology(self, fpath_toy_hpo: str):
+        o: hp.ontology.Ontology = load_ontology(fpath_toy_hpo)
 
         assert o is not None, "Ontology must not be None"
         assert isinstance(o, hp.ontology.Ontology)
@@ -49,10 +44,11 @@ class TestLoad:
         assert all([o.get_term(k).identifier == k or k in o.get_term(k).alt_term_ids for k in o.term_ids]), \
             "Each term ID must be either primary or alternative ID"
 
-    def test_load_minimal_ontology_backed_by_csr(self):
+    def test_load_minimal_ontology_backed_by_csr(self, fpath_toy_hpo: str):
         term_factory = hp.ontology.load.obographs.MinimalTermFactory()
         graph_factory = hp.graph.CsrGraphFactory()
-        o: hp.ontology.MinimalOntology = load_minimal_ontology(TOY_HPO, term_factory=term_factory,
+        o: hp.ontology.MinimalOntology = load_minimal_ontology(fpath_toy_hpo,
+                                                               term_factory=term_factory,
                                                                graph_factory=graph_factory)
         assert o is not None, "Ontology must not be None"
 
@@ -66,9 +62,9 @@ class TestLoad:
         assert o is not None, "Ontology must not be None"
 
     @pytest.mark.skip
-    def test_print_stats(self):
+    def test_print_stats(self, fpath_toy_hpo: str):
         import json
-        with open(TOY_HPO) as fh:
+        with open(fpath_toy_hpo) as fh:
             graphs = json.load(fh)
 
         graph = graphs['graphs'][0]
@@ -101,8 +97,8 @@ class TestTerms:
     """
 
     @pytest.fixture(scope='class')
-    def toy_ontology(self) -> hpotk.Ontology:
-        return load_ontology(TOY_HPO)
+    def toy_ontology(self, fpath_toy_hpo: str) -> hpotk.Ontology:
+        return load_ontology(fpath_toy_hpo)
 
     def test_term_properties(self, toy_ontology: hpotk.Ontology):
         # Test properties of a Term

--- a/tests/test_obographs.py
+++ b/tests/test_obographs.py
@@ -1,24 +1,10 @@
-import os
-
-import pytest
-from pkg_resources import resource_filename
-
 import hpotk
-from hpotk import TermId
-
-TOY_HPO = resource_filename(__name__, os.path.join('data', 'hp.toy.json'))
-
-hpotk.util.setup_logging()
 
 
 class TestTerms:
     """
     We only load the ontology once, and we test the properties of the loaded data.
     """
-
-    @pytest.fixture(scope='class')
-    def toy_hpo(self) -> hpotk.Ontology:
-        return hpotk.load_ontology(TOY_HPO)
 
     def test_term_properties(self, toy_hpo: hpotk.Ontology):
         # Test properties of a Term
@@ -29,7 +15,7 @@ class TestTerms:
         assert term.definition == 'Any abnormality of the cardiovascular system.'
         assert term.comment == 'The cardiovascular system consists of the heart, vasculature, and the lymphatic system.'
         assert not term.is_obsolete
-        assert term.alt_term_ids == (TermId.from_curie('HP:0003116'),)
+        assert term.alt_term_ids == (hpotk.TermId.from_curie('HP:0003116'),)
 
         synonyms = term.synonyms
         assert len(synonyms) == 3
@@ -53,7 +39,7 @@ class TestTerms:
         assert three.xrefs is None
 
         assert term.xrefs == tuple(
-            TermId.from_curie(curie) for curie in
+            hpotk.TermId.from_curie(curie) for curie in
             ('UMLS:C0243050', 'UMLS:C0007222', 'MSH:D018376', 'SNOMEDCT_US:49601007', 'MSH:D002318')
         )
 
@@ -65,4 +51,4 @@ class TestTerms:
         assert synonym.name == 'Abnormally shaped heart'
         assert synonym.category == hpotk.model.SynonymCategory.EXACT
         assert synonym.synonym_type == hpotk.model.SynonymType.LAYPERSON_TERM
-        assert synonym.xrefs == [TermId.from_curie('ORCID:0000-0001-5208-3432')]
+        assert synonym.xrefs == [hpotk.TermId.from_curie('ORCID:0000-0001-5208-3432')]

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,16 +1,13 @@
-import os
 import typing
 
 import pytest
-from pkg_resources import resource_filename
 
 import hpotk
+
 from hpotk.model import Identified, ObservableFeature, TermId
-from hpotk.ontology.load.obographs import load_minimal_ontology
 from hpotk.validate import ValidationResult, ValidationLevel
 from hpotk.validate import AnnotationPropagationValidator, PhenotypicAbnormalityValidator, ObsoleteTermIdsValidator
 
-TOY_HPO = resource_filename(__name__, os.path.join('data', 'hp.toy.json'))
 
 
 class SimpleFeature(Identified, ObservableFeature):
@@ -28,22 +25,17 @@ class SimpleFeature(Identified, ObservableFeature):
         return self._status
 
 
-class TestBaseRuleValidator:
-
-    @pytest.fixture
-    def toy_hpo(self) -> hpotk.MinimalOntology:
-        return load_minimal_ontology(TOY_HPO)
-
-    @pytest.fixture
-    def example_terms(self) -> typing.Sequence[SimpleFeature]:
-        return [SimpleFeature('HP:0001166', True),  # Arachnodactyly
-                SimpleFeature('HP:0001250', True),  # Seizure
-                SimpleFeature('HP:0032648', True),  # Tubularization of Bowman capsule
-                SimpleFeature('HP:0000805', False)  # excluded Enuresis
-                ]
+@pytest.fixture
+def example_terms() -> typing.Sequence[SimpleFeature]:
+    return (
+        SimpleFeature('HP:0001166', True),  # Arachnodactyly
+        SimpleFeature('HP:0001250', True),  # Seizure
+        SimpleFeature('HP:0032648', True),  # Tubularization of Bowman capsule
+        SimpleFeature('HP:0000805', False)  # excluded Enuresis
+    )
 
 
-class TestAnnotationPropagationValidator(TestBaseRuleValidator):
+class TestAnnotationPropagationValidator:
 
     @pytest.fixture
     def validator(self, toy_hpo: hpotk.MinimalOntology) -> AnnotationPropagationValidator:
@@ -105,7 +97,7 @@ class TestAnnotationPropagationValidator(TestBaseRuleValidator):
                 f'{toy_hpo.get_term(ancestor_curie).name} [{ancestor_curie}]' == first.message)
 
 
-class TestPhenotypicAbnormalityValidator(TestBaseRuleValidator):
+class TestPhenotypicAbnormalityValidator:
 
     @pytest.fixture
     def validator(self, toy_hpo: hpotk.MinimalOntology) -> PhenotypicAbnormalityValidator:
@@ -140,7 +132,7 @@ class TestPhenotypicAbnormalityValidator(TestBaseRuleValidator):
                                                               'Phenotypic abnormality [HP:0000118]')
 
 
-class TestObsoleteTermIdsValidator(TestBaseRuleValidator):
+class TestObsoleteTermIdsValidator:
 
     @pytest.fixture
     def validator(self, toy_hpo: hpotk.MinimalOntology) -> ObsoleteTermIdsValidator:


### PR DESCRIPTION
Add support for working with term ID indices, simplify the CSR data structures. 

Use `IndexedOntologyGraph` and `CsrIndexedGraphFactory` as default in `hpotk.load_ontology` and `hpotk.load_minimal_ontology`.