### PR TITLE
Add `OntologyStore` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Loading HPO is as simple as:
 ```python
 import hpotk
 
-hpo = hpotk.load_ontology('http://purl.obolibrary.org/obo/hp.json')
+store = hpotk.configure_ontology_store()
+hpo = store.load_hpo()
 ```
 
-Now you have HPO concepts and the ontology hierarchy at your fingertips.
+Now you have the concepts and the hierarchy of the latest HPO release at your fingertips.
 
 Next, load the HPO disease annotations by running:
 

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -11,6 +11,7 @@ This guide includes self-contained tutorials for using HPO toolkit to work with 
   :caption: Contents:
 
   load-ontology
+  use-ontology
   use-hierarchy
   load-hpo-annotations
   validate-phenotypic-features

--- a/docs/user-guide/load-ontology.rst
+++ b/docs/user-guide/load-ontology.rst
@@ -8,8 +8,16 @@ Loading HPO is the first item of all analysis task lists.
 HPO toolkit supports loading the ontology data from an `Obographs <https://github.com/geneontology/obographs>`_
 JSON file which is available for download from the `HPO website <https://hpo.jax.org/app/data/ontology>`_.
 
-Minimal ontology
+Ontology loaders
+****************
+
+HPO toolkit provides 2 ways for loading an ontology: a low-level loader and a high-level :class:`OntologyStore`.
+
+Low level loader
 ^^^^^^^^^^^^^^^^
+
+The low-level loader function loads a :class:`hpotk.ontology.MinimalOntology` from a local or remote resource.
+The loader will open the resource and parse its contents into an ontology. Any failure is reported as an exception.
 
 Let's load the HPO version released on Oct 9th, 2023:
 
@@ -19,13 +27,59 @@ Let's load the HPO version released on Oct 9th, 2023:
 
   >>> url = 'https://github.com/obophenotype/human-phenotype-ontology/releases/download/v2023-10-09/hp.json'
   >>> hpo = hpotk.load_minimal_ontology(url)
+  >>> hpo.version
+  '2023-10-09'
 
-The loader fetches the Obographs JSON file and loads the data into :class:`hpotk.ontology.MinimalOntology`.
+We use the :func:`hpotk.ontology.load.obographs.load_minimal_ontology` function to fetch the Obographs JSON file
+and to load the data into :class:`hpotk.ontology.MinimalOntology`.
 
 .. note::
 
-  The loader can fetch the HPO from a URL, and it transparently handles gzipped files
-  if the file name ends with `.gz` suffix.
+  The loader can fetch the HPO from a local path (relative or absolute), or from a URL,
+  and it transparently handles decompression of gzipped files if the file name has a `.gz` suffix.
+
+A similar loader function :func:`hpotk.ontology.load.obographs.load_ontology` exists
+to load an :class:`hpotk.ontology.Ontology`.
+
+
+Ontology store
+^^^^^^^^^^^^^^
+
+Alternatively, we can use the :class:`hpotk.util.store.OntologyStore`, a class that wraps the low-level loader
+and provides more convenience.
+
+Using `OntologyStore` provides several benefits. `OntologyStore` caches the ontology data files in a local directory
+to prevent downloading a HPO release more than once, to save time spent during slow network access.
+
+.. doctest:: load-minimal-ontology
+
+  >>> store = hpotk.configure_ontology_store()
+  >>> hpo = store.load_minimal_hpo(release='v2023-10-09')
+  >>> hpo.version
+  '2023-10-09'
+
+The store will download the ontology file the first time a release (e.g. `v2023-10-09`) is requested, and subsequent
+loads will skip the download. The `release` must be a release tag, as defined
+on `HPO release page<https://github.com/obophenotype/human-phenotype-ontology/releases>`_.
+
+Moreover, `OntologyStore` can get you a latest release by *not* specifying the `release` option.
+
+.. doctest:: load-minimal-ontology
+
+  >>> hpo_latest = store.load_minimal_hpo()  # doctest: +SKIP
+  >>> hpo_latest.version  # doctest: +SKIP
+  '2024-03-06'
+
+As of the time of this writing, ``2024-03-06`` is the latest HPO release.
+
+
+Quick overview
+**************
+
+Here we provide a quick walkthrough of the basic functionality of an ontology.
+
+Minimal ontology
+^^^^^^^^^^^^^^^^
 
 Having `MinimalOntology`, we can do several checks. We can check the HPO version:
 

--- a/docs/user-guide/load-ontology.rst
+++ b/docs/user-guide/load-ontology.rst
@@ -60,9 +60,9 @@ to prevent downloading a HPO release more than once, to save time spent during s
 
 The store will download the ontology file the first time a release (e.g. `v2023-10-09`) is requested, and subsequent
 loads will skip the download. The `release` must be a release tag, as defined
-on `HPO release page<https://github.com/obophenotype/human-phenotype-ontology/releases>`_.
+in the tag section of the `HPO release page <https://github.com/obophenotype/human-phenotype-ontology/tags>`_.
 
-Moreover, `OntologyStore` can get you a latest release by *not* specifying the `release` option.
+Moreover, `OntologyStore` will load the *latest* release, if the `release` option is omitted.
 
 .. doctest:: load-minimal-ontology
 
@@ -73,112 +73,8 @@ Moreover, `OntologyStore` can get you a latest release by *not* specifying the `
 As of the time of this writing, ``2024-03-06`` is the latest HPO release.
 
 
-Quick overview
-**************
+Next steps
+**********
 
-Here we provide a quick walkthrough of the basic functionality of an ontology.
-
-Minimal ontology
-^^^^^^^^^^^^^^^^
-
-Having `MinimalOntology`, we can do several checks. We can check the HPO version:
-
-.. doctest:: load-minimal-ontology
-
-  >>> hpo.version
-  '2023-10-09'
-
-check that the Oct 9th release has *17,664* terms:
-
-.. doctest:: load-minimal-ontology
-
-  >>> len(hpo)
-  17664
-
-check that `HP:0001250` is/was a valid identifier:
-
-.. doctest:: load-minimal-ontology
-
-  >>> 'HP:0001250' in hpo
-  True
-
-check that `HP:0001250` in fact represents *Seizure*:
-
-.. doctest:: load-minimal-ontology
-
-  >>> seizure = hpo.get_term('HP:0001250')
-  >>> seizure.name
-  'Seizure'
-
-or print names of its children in alphabetical order:
-
-.. doctest:: load-minimal-ontology
-
-  >>> for child in sorted(hpo.get_term_name(child)
-  ...                     for child in hpo.graph.get_children(seizure)):
-  ...   print(child)
-  Bilateral tonic-clonic seizure
-  Dialeptic seizure
-  Focal-onset seizure
-  Generalized-onset seizure
-  Infection-related seizure
-  Maternal seizure
-  Motor seizure
-  Neonatal seizure
-  Nocturnal seizures
-  Non-motor seizure
-  Reflex seizure
-  Status epilepticus
-  Symptomatic seizures
-
-The terms of :class:`hpotk.ontology.MinimalOntology` are instances of :class:`hpotk.model.MinimalTerm` and contain a subset
-of the term metadata such as identifier, labels, and alternative IDs. The simplified are useful for tasks that
-use the ontology hierarchy. However, the tasks that need the full term metadata should use `Ontology`.
-
-Ontology
-^^^^^^^^
-
-Unsurprisingly, loading ontology is very similar to loading minimal ontology. We use `hpotk.load_ontology`
-loader function:
-
-.. testsetup:: load-ontology
-
-  import hpotk
-  url = 'https://github.com/obophenotype/human-phenotype-ontology/releases/download/v2023-10-09/hp.json'
-
-.. doctest:: load-ontology
-
-  >>> hpo = hpotk.load_ontology(url)
-  >>> hpo.version
-  '2023-10-09'
-
-Same as above, the loader parses the Obographs JSON file and returns an ontology. However, this time
-it is an instance :class:`hpotk.ontology.Ontology` with :class:`hpotk.model.Term` - the term with full metadata.
-
-So, now we can access the definition of the seizure:
-
-.. doctest:: load-ontology
-
-  >>> seizure = hpo.get_term('HP:0001250')
-  >>> definition = seizure.definition
-  >>> definition.definition
-  'A seizure is an intermittent abnormality of nervous system physiology characterised by a transient occurrence of signs and/or symptoms due to abnormal excessive or synchronous neuronal activity in the brain.'
-  >>> definition.xrefs
-  ('https://orcid.org/0000-0002-0736-9199', 'PMID:15816939')
-
-
-or check out seizure's synonyms:
-
-.. doctest:: load-ontology
-
-  >>> for synonym in seizure.synonyms:
-  ...   print(synonym.name)
-  Epileptic seizure
-  Seizures
-  Epilepsy
-
-.. note::
-
-  Since `Ontology` is a subclass of `MinimalOntology`, any function that needs `MinimalOntology` will work just fine
-  when provided with `Ontology`.
-
+Loading an ontology is a prerequisite for doing anything useful with the ontology data. Check out
+the :ref:`use-ontology` section for an overview of the functionality.

--- a/docs/user-guide/use-ontology.rst
+++ b/docs/user-guide/use-ontology.rst
@@ -1,0 +1,133 @@
+.. _use-ontology:
+
+============
+Use ontology
+============
+
+HPO toolkit simplifies working with Human Phenotype Ontology from Python by providing APIs
+for accessing the ontology data. Here we show how to access the data.
+
+  We assume the reader is familiar with loading ontology from an Obographs JSON file as described
+  in the :ref:`rstload-ontology` section.
+
+HPO toolkit represents the ontology data either as :class:`hpotk.ontology.MinimalOntology`
+or as its subclass :class:`hpotk.ontology.Ontology`.
+The two classes are mostly equivalent but the `MinimalOntology` terms contain less metadata than the `Ontology` terms.
+We recommend using `MinimalOntology` for applications that mostly care about the ontology hierarchy and
+`Ontology` is suitable for applications that use definitions, synonyms, or cross-references of the ontology terms,
+such as natural language processing applications.
+
+
+Minimal ontology
+^^^^^^^^^^^^^^^^
+
+Let's see what we can do with a `MinimalOntology`.
+
+We start with loading the version `v2023-10-09` using :class:`hpotk.util.store.OntologyStore`:
+
+.. doctest:: load-minimal-ontology
+
+  >>> import hpotk
+  >>> store = hpotk.configure_ontology_store()
+
+  >>> hpo = store.load_minimal_hpo(release='v2023-10-09')
+
+We can check the HPO version:
+
+.. doctest:: load-minimal-ontology
+
+  >>> hpo.version
+  '2023-10-09'
+
+check that the release has *17,664* terms:
+
+.. doctest:: load-minimal-ontology
+
+  >>> len(hpo)
+  17664
+
+check that `HP:0001250` is/was a valid term id:
+
+.. doctest:: load-minimal-ontology
+
+  >>> 'HP:0001250' in hpo
+  True
+
+check that `HP:0001250` in fact represents *Seizure*:
+
+.. doctest:: load-minimal-ontology
+
+  >>> seizure = hpo.get_term('HP:0001250')
+  >>> seizure.name
+  'Seizure'
+
+or print the names of its children in alphabetical order:
+
+.. doctest:: load-minimal-ontology
+
+  >>> for child in sorted(hpo.get_term_name(child)
+  ...                     for child in hpo.graph.get_children(seizure)):
+  ...   print(child)
+  Bilateral tonic-clonic seizure
+  Dialeptic seizure
+  Focal-onset seizure
+  Generalized-onset seizure
+  Infection-related seizure
+  Maternal seizure
+  Motor seizure
+  Neonatal seizure
+  Nocturnal seizures
+  Non-motor seizure
+  Reflex seizure
+  Status epilepticus
+  Symptomatic seizures
+
+The terms of :class:`hpotk.ontology.MinimalOntology` are instances of :class:`hpotk.model.MinimalTerm` and contain a subset
+of the term metadata such as identifier, labels, and alternative IDs. The simplified are useful for tasks that
+use the ontology hierarchy.
+
+Ontology
+^^^^^^^^
+
+Unsurprisingly, loading ontology is very similar to loading minimal ontology. Same as above,
+we use :class:`hpotk.util.store.OntologyStore`:
+
+.. doctest:: load-ontology
+
+  >>> import hpotk
+  >>> store = hpotk.configure_ontology_store()
+
+  >>> hpo = store.load_hpo(release='v2023-10-09')
+  >>> hpo.version
+  '2023-10-09'
+
+Same as above, the ontology store will check the local cache for the ontology data file of the requested release
+and fetch the file from HPO release page if missing. Then, the file is parsed into :class:`hpotk.ontology.Ontology`,
+where the ontology terms are represented as :class:`hpotk.model.Term`.
+
+Thanks to the additional metadata present in a `Term`, we can also access the definition of the *Seizure*:
+
+.. doctest:: load-ontology
+
+  >>> seizure = hpo.get_term('HP:0001250')
+  >>> definition = seizure.definition
+  >>> definition.definition
+  'A seizure is an intermittent abnormality of nervous system physiology characterised by a transient occurrence of signs and/or symptoms due to abnormal excessive or synchronous neuronal activity in the brain.'
+  >>> definition.xrefs
+  ('https://orcid.org/0000-0002-0736-9199', 'PMID:15816939')
+
+or its synonyms:
+
+.. doctest:: load-ontology
+
+  >>> for synonym in seizure.synonyms:
+  ...   print(synonym.name)
+  Epileptic seizure
+  Seizures
+  Epilepsy
+
+.. note::
+
+  Since `Ontology` is a subclass of `MinimalOntology`, any function that needs `MinimalOntology` will work just fine
+  when provided with `Ontology`.
+

--- a/src/hpotk/__init__.py
+++ b/src/hpotk/__init__.py
@@ -18,3 +18,4 @@ from .model import TermId, Term, MinimalTerm, Synonym, SynonymType, SynonymCateg
 from .ontology import Ontology, MinimalOntology
 
 from .ontology.load.obographs import load_minimal_ontology, load_ontology
+from .util.store import OntologyType, OntologyStore, configure_ontology_store

--- a/src/hpotk/util/__init__.py
+++ b/src/hpotk/util/__init__.py
@@ -1,4 +1,4 @@
-from . import sort
+from . import sort  # TODO: probably not necessary
 
 from ._io import looks_like_url, looks_gzipped
 from ._io import open_text_io_handle, open_text_io_handle_for_reading, open_text_io_handle_for_writing

--- a/src/hpotk/util/store/__init__.py
+++ b/src/hpotk/util/store/__init__.py
@@ -1,0 +1,11 @@
+"""
+The `hpotk.util.store` package provides
+"""
+
+from ._api import OntologyType, OntologyStore
+from ._config import configure_ontology_store
+
+__all__ = [
+    'OntologyType', 'OntologyStore',
+    'configure_ontology_store',
+]

--- a/src/hpotk/util/store/_api.py
+++ b/src/hpotk/util/store/_api.py
@@ -8,7 +8,7 @@ from hpotk.ontology import MinimalOntology, Ontology
 
 class OntologyType(enum.Enum):
     """
-    Enum with the ontologies supported by the :class:`OntologyStore` of the HPO toolkit.
+    Enum with the ontologies supported by the :class:`OntologyStore`.
     """
 
     HPO = 'HPO', 'HP'
@@ -50,6 +50,13 @@ class OntologyStore(metaclass=abc.ABCMeta):
             ontology_type: OntologyType,
             release: typing.Optional[str] = None,
     ) -> MinimalOntology:
+        """
+        Load a `release` of a given `ontology_type` as a minimal ontology.
+
+        :param ontology_type: the desired ontology type, see :class:`OntologyType` for a list of supported ontologies.
+        :param release: a `str` with the ontology release tag or `None` if the latest ontology should be fetched.
+        :return: a minimal ontology.
+        """
         pass
 
     @abc.abstractmethod
@@ -58,6 +65,13 @@ class OntologyStore(metaclass=abc.ABCMeta):
             ontology_type: OntologyType,
             release: typing.Optional[str] = None,
     ) -> Ontology:
+        """
+        Load a `release` of a given `ontology_type` as an ontology.
+
+        :param ontology_type: the desired ontology type, see :class:`OntologyType` for a list of supported ontologies.
+        :param release: a `str` with the ontology release tag or `None` if the latest ontology should be fetched.
+        :return: an ontology.
+        """
         pass
 
     @property

--- a/src/hpotk/util/store/_api.py
+++ b/src/hpotk/util/store/_api.py
@@ -1,0 +1,95 @@
+import abc
+import enum
+import logging
+import typing
+
+from hpotk.ontology import MinimalOntology, Ontology
+
+
+class OntologyType(enum.Enum):
+    """
+    Enum with the ontologies supported by the :class:`OntologyStore` of the HPO toolkit.
+    """
+
+    HPO = 'HPO', 'HP'
+    """
+    Human Phenotype Ontology.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        obj = object.__new__(cls)
+        obj._value_ = args[0]
+        return obj
+
+    def __init__(self, _: str, identifier: str):
+        self._id_ = identifier
+
+    @property
+    def identifier(self) -> str:
+        """
+        Get a `str` with the ontology identifier (e.g. ``HP`` for HPO).
+        """
+        return self._id_
+
+
+class OntologyStore(metaclass=abc.ABCMeta):
+    """
+    `OntologyStore` stores versions of the supported ontologies.
+    """
+
+    def __init__(
+            self,
+            store_dir: str,
+    ):
+        self._logger = logging.getLogger(__name__)
+        self._store_dir = store_dir
+
+    @abc.abstractmethod
+    def load_minimal_ontology(
+            self,
+            ontology_type: OntologyType,
+            release: typing.Optional[str] = None,
+    ) -> MinimalOntology:
+        pass
+
+    @abc.abstractmethod
+    def load_ontology(
+            self,
+            ontology_type: OntologyType,
+            release: typing.Optional[str] = None,
+    ) -> Ontology:
+        pass
+
+    @property
+    def store_dir(self) -> str:
+        """
+        Get a `str` with a platform specific absolute path to the data directory.
+
+        The data directory points to `$HOME/.hpo-toolkit` on UNIX and `$HOME/hpo-toolkit` on Windows.
+        The folder is created if it does not exist.
+        """
+        return self._store_dir
+
+    def load_minimal_hpo(
+            self,
+            release: typing.Optional[str] = None,
+    ) -> MinimalOntology:
+        """
+        A convenience method for loading a specific HPO release.
+
+        :param release: an optional `str` with the desired HPO release (if `None`, the latest HPO will be provided).
+        :return: a :class:`hpotk.MinimalOntology` with the HPO data.
+        """
+        return self.load_minimal_ontology(OntologyType.HPO, release=release)
+
+    def load_hpo(
+            self,
+            release: typing.Optional[str] = None,
+    ) -> Ontology:
+        """
+        A convenience method for loading a specific HPO release.
+
+        :param release: an optional `str` with the desired HPO release (if `None`, the latest HPO will be provided).
+        :return: a :class:`hpotk.Ontology` with the HPO data.
+        """
+        return self.load_ontology(OntologyType.HPO, release=release)

--- a/src/hpotk/util/store/_config.py
+++ b/src/hpotk/util/store/_config.py
@@ -1,0 +1,51 @@
+import os
+import platform
+import re
+import typing
+from pathlib import Path
+
+from ._api import OntologyStore
+from ._github import GitHubOntologyStore
+
+
+def configure_ontology_store(
+        store_dir: typing.Optional[str] = None,
+) -> OntologyStore:
+    """
+    Configure and create the default ontology store.
+
+    :param: a `str` pointing to an existing directory for caching the ontology files
+      or `None` if the platform-specific default folder should be used.
+    :returns: an :class:`OntologyStore`.
+    :raises: `ValueError` if something goes wrong.
+    """
+    if store_dir is None:
+        store_dir = get_default_ontology_store_dir()
+    else:
+        if not os.path.isdir(store_dir):
+            raise ValueError(f'`store_dir` must point to an existing directory')
+    return GitHubOntologyStore(store_dir=store_dir)
+
+
+def get_default_ontology_store_dir() -> str:
+    """
+    Get a platform specific absolute path to the data directory.
+
+    The data directory points to `$HOME/.hpo-toolkit` on UNIX and `$HOME/hpo-toolkit` on Windows.
+    The folder is created if it does not exist.
+    """
+    ps = platform.system()
+
+    if re.match('(linux)|(darwin)', ps, re.IGNORECASE):
+        store_dir_name = '.hpo-toolkit'
+    elif re.match('windows', ps, re.IGNORECASE):
+        store_dir_name = 'hpo-toolkit'
+    else:
+        raise ValueError(f'Unsupported platform {ps}')
+
+    dir_name = os.path.join(Path.home(), store_dir_name)
+
+    if not os.path.isdir(dir_name):
+        os.makedirs(dir_name)
+
+    return dir_name

--- a/src/hpotk/util/store/_github.py
+++ b/src/hpotk/util/store/_github.py
@@ -1,0 +1,130 @@
+import json
+import os
+import typing
+import urllib
+from urllib.request import urlopen, HTTPError
+
+from hpotk.ontology import Ontology, MinimalOntology
+from hpotk.ontology.load.obographs import load_minimal_ontology, load_ontology
+from ._api import OntologyType, OntologyStore
+
+
+class GitHubOntologyStore(OntologyStore):
+    """
+    `GitHubOntologyStore` fetches an Obographs ontology JSON from GitHub.
+    """
+
+    ONTOLOGY_CREDENTIALS = {
+        OntologyType.HPO: {
+            'owner': 'obophenotype',
+            'repo': 'human-phenotype-ontology',
+        }
+    }
+
+    def __init__(
+            self,
+            store_dir: str,
+            timeout: int = 10,
+    ):
+        super().__init__(store_dir=store_dir)
+        self._timeout = timeout
+        self._tag_api_url = 'https://api.github.com/repos/{owner}/{repo}/tags'
+        self._release_url = 'https://github.com/{owner}/{repo}/releases/download/{release}/{ontology_id}.json'
+
+    def load_minimal_ontology(self, ontology_type: OntologyType,
+                              release: typing.Optional[str] = None) -> MinimalOntology:
+        return self._impl_load_ontology(
+            load_minimal_ontology,
+            ontology_type,
+            release,
+        )
+
+    def load_ontology(
+            self,
+            ontology_type: OntologyType,
+            release: typing.Optional[str] = None,
+    ) -> Ontology:
+        return self._impl_load_ontology(
+            load_ontology,
+            ontology_type,
+            release,
+        )
+
+    def _impl_load_ontology(
+            self,
+            loader_func,
+            ontology_type: OntologyType,
+            release: typing.Optional[str] = None,
+    ):
+        if ontology_type not in self.ONTOLOGY_CREDENTIALS:
+            raise ValueError(f'Ontology {ontology_type} not among the known ontology credentials')
+        credentials = self.ONTOLOGY_CREDENTIALS[ontology_type]
+
+        # Figure out the desired release
+        if release is None:
+            release = self._fetch_latest_tag_from_github(credentials)
+        self._logger.debug('Using %s as the ontology release', release)
+
+        # Check if we have the release in the local storage
+        # and download the JSON file if not.
+        fpath_ontology = self._download_ontology_if_missing(credentials, ontology_type.identifier, release)
+
+        # Load the ontology
+        return loader_func(fpath_ontology)
+
+    def _download_ontology_if_missing(
+            self,
+            credentials: typing.Mapping[str, str],
+            ontology_id: str,
+            release: str,
+    ) -> str:
+        fdir_ontology = os.path.join(self.store_dir, ontology_id)
+        fpath_ontology = os.path.join(fdir_ontology, f'{ontology_id.lower()}.{release}.json')
+        if not os.path.isfile(fpath_ontology):
+            os.makedirs(fdir_ontology, exist_ok=True)
+            owner = credentials['owner']
+            repo = credentials['repo']
+            url = self._release_url.format(
+                owner=owner,
+                repo=repo,
+                release=release,
+                ontology_id=ontology_id.lower(),
+            )
+            self._logger.info('Downloading ontology from %s', url)
+            self._logger.info('Storing the ontology at %s', fpath_ontology)
+            try:
+                with urlopen(url, timeout=self._timeout) as response, open(fpath_ontology, 'wb') as fh_ontology:
+                    fh_ontology.write(response.read())
+            except HTTPError as he:
+                if he.code == 404:
+                    # Most likely a non-existing release.
+                    raise ValueError(f'Could not find {release} on GitHub')
+                else:
+                    # Another error.
+                    raise he
+            self._logger.info('Download complete')
+
+        return fpath_ontology
+
+    def _fetch_latest_tag_from_github(self, credentials: typing.Mapping[str, str]):
+        self._logger.debug('Release unset, getting the latest')
+        tag_names = self._get_tag_names(
+            owner=credentials['owner'],
+            repo=credentials['repo'],
+        )
+        # We assume lexicographic sorting of the tags
+        return max(tag_names)
+
+    def _get_tag_names(self, owner: str, repo: str) -> typing.Iterable[str]:
+        tag_url = self._tag_api_url.format(owner=owner, repo=repo)
+        self._logger.debug('Pulling tag from %s', tag_url)
+
+        with urllib.request.urlopen(tag_url, timeout=self._timeout) as r:
+            tags = json.load(r)
+
+        if len(tags) == 0:
+            raise ValueError('No tags could be fetched from GitHub tag API')
+        else:
+            self._logger.debug('Fetched %d tags', len(tags))
+
+        return [tag['name'] for tag in tags]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+
+import pytest
+
+import hpotk
+
+
+@pytest.mark.skip('Needs an internet connection')
+class TestGitHubOntologyStore:
+
+    def test_load_minimal_hpo(
+            self,
+            tmp_path: Path,
+    ):
+        assert len(os.listdir(tmp_path)) == 0  # We start with the clean slate.
+
+        store = hpotk.configure_ontology_store(store_dir=str(tmp_path))
+        assert len(os.listdir(tmp_path)) == 0  # Creating the store does nothing.
+
+        release = 'v2024-03-06'
+        hpo = store.load_minimal_hpo(release=release)
+
+        assert isinstance(hpo, hpotk.MinimalOntology)
+        assert hpo.version == release[1:]
+
+        fpath_expected = os.path.join(tmp_path, 'HP', f'hp.{release}.json')
+        assert os.path.isfile(fpath_expected)
+
+    def test_load_minimal_hpo__invalid_release(
+            self,
+            tmp_path: Path,
+    ):
+        store = hpotk.configure_ontology_store(store_dir=str(tmp_path))
+
+        release = 'v3400-12-31'
+        with pytest.raises(ValueError) as e:
+            store.load_minimal_hpo(release=release)
+
+        assert e.value.args[0] == f'Could not find {release} on GitHub'


### PR DESCRIPTION
Adding the `OntologyStore` API for local caching of the ontology releases.

Closes #7 