### PR TITLE
Fix bug in `HpoFrequency.frequency`

### DIFF
--- a/src/hpotk/constants/hpo/frequency.py
+++ b/src/hpotk/constants/hpo/frequency.py
@@ -28,7 +28,7 @@ class HpoFrequency(Identified):
 
     @property
     def frequency(self) -> float:
-        return self._lower + self._upper / 2
+        return (self._lower + self._upper) / 2
 
     def __eq__(self, other):
         return (

--- a/tests/annotations/load/test_hpoa.py
+++ b/tests/annotations/load/test_hpoa.py
@@ -74,7 +74,7 @@ class TestHpoaLoader:
         )  # Spontaneous cerebrospinal fluid leak
         assert ann is not None
         assert ann.identifier.value == "HP:0032934"
-        assert (ann.numerator, ann.denominator) == (2, 50)
+        assert (ann.numerator, ann.denominator) == (1, 50)
 
         assert len(ann.onsets) == 2
         assert all(
@@ -83,8 +83,8 @@ class TestHpoaLoader:
         )
 
         assert ann.onset_counts("HP:0003674") is None  # Onset
-        assert ann.onset_counts("HP:0003581") == (2, 50)  # Adult onset
-        assert ann.onset_counts("HP:0011462") == (2, 50)  # Young adult onset
+        assert ann.onset_counts("HP:0003581") == (1, 50)  # Adult onset
+        assert ann.onset_counts("HP:0011462") == (1, 50)  # Young adult onset
 
     @staticmethod
     def check_hyperekplexia2(disease: HpoDisease):

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,29 +1,52 @@
+import pytest
+
+import hpotk
+from hpotk.constants.hpo.base import PHENOTYPIC_ABNORMALITY, MODE_OF_INHERITANCE
+from hpotk.constants.hpo.frequency import parse_hpo_frequency
+from hpotk.constants.hpo.frequency import (
+    EXCLUDED,
+    VERY_RARE,
+    OCCASIONAL,
+    FREQUENT,
+    VERY_FREQUENT,
+    OBLIGATE,
+)
+
+
 class TestHpoBase:
     def test_phenotypic_abnormality(self):
-        from hpotk.constants.hpo.base import PHENOTYPIC_ABNORMALITY
-
         assert PHENOTYPIC_ABNORMALITY.value == "HP:0000118"
 
     def test_mode_of_inheritance(self):
-        from hpotk.constants.hpo.base import MODE_OF_INHERITANCE
-
         assert MODE_OF_INHERITANCE.value == "HP:0000005"
 
 
 class TestHpoFrequency:
-    def test_frequencies(self):
-        from hpotk.constants.hpo.frequency import (
-            EXCLUDED,
-            VERY_RARE,
-            OCCASIONAL,
-            FREQUENT,
-            VERY_FREQUENT,
-            OBLIGATE,
-        )
-
+    def test_term_ids(self):
         assert EXCLUDED.value == "HP:0040285"
         assert VERY_RARE.value == "HP:0040284"
         assert OCCASIONAL.value == "HP:0040283"
         assert FREQUENT.value == "HP:0040282"
         assert VERY_FREQUENT.value == "HP:0040281"
         assert OBLIGATE.value == "HP:0040280"
+
+    @pytest.mark.parametrize(
+        "term_id,frequency",
+        [
+            (EXCLUDED, 0.0),
+            (VERY_RARE, 0.025),
+            (OCCASIONAL, 0.16999999999),
+            (FREQUENT, 0.545),
+            (VERY_FREQUENT, 0.895),
+            (OBLIGATE, 1.0),
+        ],
+    )
+    def test_frequency(
+        self,
+        term_id: hpotk.TermId,
+        frequency: float,
+    ):
+        hpo_frequency = parse_hpo_frequency(term_id)
+
+        assert hpo_frequency is not None
+        assert hpo_frequency.frequency == pytest.approx(frequency)


### PR DESCRIPTION
Fix bug where missing parentheses lead to incorrect frequency computation in `hpotk.constants.hpo.frequency.HpoFrequency`.