### PR TITLE
The annotated items do not need to have a term ID anymore

### DIFF
--- a/src/hpotk/annotations/_api.py
+++ b/src/hpotk/annotations/_api.py
@@ -8,7 +8,6 @@ from hpotk.model import (
     Versioned,
     CURIE_OR_TERM_ID_OR_IDENTIFIED,
 )
-from hpotk.model import TermId
 from hpotk.util import extract_term_id
 
 
@@ -31,7 +30,6 @@ A world item annotation with an identifier and present or excluded state.
 
 class AnnotatedItem(
     typing.Generic[ANNOTATION],
-    Identified,
     metaclass=abc.ABCMeta,
 ):
     """
@@ -110,9 +108,3 @@ class AnnotatedItemContainer(
             stacklevel=2,
         )
         return list(self)
-
-    def item_ids(self) -> typing.Iterable[TermId]:
-        """
-        :return: an iterable over all item identifiers.
-        """
-        return (item.identifier for item in self)

--- a/tests/annotations/load/test_hpoa.py
+++ b/tests/annotations/load/test_hpoa.py
@@ -21,7 +21,7 @@ class TestHpoaLoader:
         assert isinstance(diseases, HpoDiseases)
 
         assert 2 == len(diseases)
-        assert {"ORPHA:123456", "OMIM:987654"} == set(map(lambda di: di.value, diseases.item_ids()))
+        assert {"ORPHA:123456", "OMIM:987654"} == set(map(lambda di: di.identifier.value, diseases))
         assert diseases.version == "2021-08-02"
 
     def test_load_older_hpo_annotations(
@@ -33,7 +33,7 @@ class TestHpoaLoader:
         assert isinstance(diseases, HpoDiseases)
 
         assert 2 == len(diseases)
-        assert {"ORPHA:123456", "OMIM:987654"} == set(map(lambda di: di.value, diseases.item_ids()))
+        assert {"ORPHA:123456", "OMIM:987654"} == set(map(lambda di: di.identifier.value, diseases))
 
     def test_load_real_shortlist(
         self,

--- a/tests/annotations/test_api.py
+++ b/tests/annotations/test_api.py
@@ -14,17 +14,6 @@ class TestHpoDiseases:
     ) -> HpoDiseases:
         return hpoa_disease_loader.load(fpath_toy_hpoa)
 
-    def test_item_ids(
-        self,
-        hpo_diseases: HpoDiseases,
-    ):
-        ids = sorted(tid.value for tid in hpo_diseases.item_ids())
-
-        assert ids == [
-            "OMIM:987654",
-            "ORPHA:123456",
-        ]
-
     def test_properties(
         self,
         hpo_diseases: HpoDiseases,


### PR DESCRIPTION
BREAKING CHANGE

The annotated items such as HPO disease models or individuals annotated with HPO terms do not need to have a `TermId`.

The requirement has been removed because it is not possible to assign a `TermId` to individuals annotated with HPO terms.

This is a BREAKING CHANGE because the identifier as the `term_ids` method has been removed from the `AnnotatedItemContainer`.